### PR TITLE
Support for multiple DbContext types

### DIFF
--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AspNetCore/Riganti.Utils.Infrastructure.AspNetCore.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AspNetCore/Riganti.Utils.Infrastructure.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.AspNetCore</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.AspNetCore</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AspNetCore/Riganti.Utils.Infrastructure.AspNetCore.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AspNetCore/Riganti.Utils.Infrastructure.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.AspNetCore</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.AspNetCore</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AspNetCore/UnitOfWork/Registry/AspNetCoreUnitOfWorkRegistry.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AspNetCore/UnitOfWork/Registry/AspNetCoreUnitOfWorkRegistry.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 
+// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.Core
 {
     public class AspNetCoreUnitOfWorkRegistry : UnitOfWorkRegistryBase

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/Riganti.Utils.Infrastructure.AutoMapper.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/Riganti.Utils.Infrastructure.AutoMapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.AutoMapper</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.AutoMapper</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/Riganti.Utils.Infrastructure.AutoMapper.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/Riganti.Utils.Infrastructure.AutoMapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.AutoMapper</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.AutoMapper</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Azure.TableStorage/Riganti.Utils.Infrastructure.Azure.TableStorage.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Azure.TableStorage/Riganti.Utils.Infrastructure.Azure.TableStorage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Azure.TableStorage</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Azure.TableStorage</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Azure.TableStorage/Riganti.Utils.Infrastructure.Azure.TableStorage.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Azure.TableStorage/Riganti.Utils.Infrastructure.Azure.TableStorage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Azure.TableStorage</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Azure.TableStorage</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Configuration/AppSettingsConfigurationBase.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Configuration/AppSettingsConfigurationBase.cs
@@ -3,6 +3,7 @@ using System.Configuration;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 
+// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.Core
 {
     public class AppSettingsConfigurationBase

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Configuration/Riganti.Utils.Infrastructure.Configuration.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Configuration/Riganti.Utils.Infrastructure.Configuration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFramework>net461</TargetFramework>
     <AssemblyName>Riganti.Utils.Infrastructure.Configuration</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Configuration</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Configuration/Riganti.Utils.Infrastructure.Configuration.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Configuration/Riganti.Utils.Infrastructure.Configuration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFramework>net461</TargetFramework>
     <AssemblyName>Riganti.Utils.Infrastructure.Configuration</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Configuration</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Core/Repository/IIncludeDefinition.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Core/Repository/IIncludeDefinition.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Linq.Expressions;
+﻿using System.Linq;
 
 namespace Riganti.Utils.Infrastructure.Core
 {

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Core/Riganti.Utils.Infrastructure.Core.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Core/Riganti.Utils.Infrastructure.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Core</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Core</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Core/Riganti.Utils.Infrastructure.Core.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Core/Riganti.Utils.Infrastructure.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Core</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Core</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Core/Riganti.Utils.Infrastructure.Core.csproj.DotSettings
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Core/Riganti.Utils.Infrastructure.Core.csproj.DotSettings
@@ -1,2 +1,10 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=helpers/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=datetimenowprovider/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=entity/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=exception/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=helpers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=query/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=repository/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=unitofwork/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=unitofwork_005Cprovider/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=unitofwork_005Cregistry/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Core/UnitOfWork/Provider/IUnitOfWorkProvider.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Core/UnitOfWork/Provider/IUnitOfWorkProvider.cs
@@ -14,7 +14,8 @@ namespace Riganti.Utils.Infrastructure.Core
         /// <summary>
         /// Gets the unit of work in the current scope.
         /// </summary>
-        IUnitOfWork GetCurrent();
+        /// <param name="ancestorLevel">0 means current unit of work, 1 means parent unit of work and so on.</param>
+        IUnitOfWork GetCurrent(int ancestorLevel = 0);
 
     }
 }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Core/UnitOfWork/Provider/UnitOfWorkProviderBase.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Core/UnitOfWork/Provider/UnitOfWorkProviderBase.cs
@@ -54,9 +54,9 @@ namespace Riganti.Utils.Infrastructure.Core
         /// <summary>
         /// Gets the unit of work in the current scope.
         /// </summary>
-        public IUnitOfWork GetCurrent()
+        public IUnitOfWork GetCurrent(int ancestorLevel = 0)
         {
-            return registry.GetCurrent();
+            return registry.GetCurrent(ancestorLevel);
         }
     }
 }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Core/UnitOfWork/Registry/IUnitOfWorkRegistry.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Core/UnitOfWork/Registry/IUnitOfWorkRegistry.cs
@@ -18,6 +18,7 @@ namespace Riganti.Utils.Infrastructure.Core
         /// <summary>
         /// Gets the unit of work in the current scope.
         /// </summary>
-        IUnitOfWork GetCurrent();
+        /// <param name="ancestorLevel">0 means current unit of work, 1 means parent unit of work and so on.</param>
+        IUnitOfWork GetCurrent(int ancestorLevel = 0);
     }
 }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Core/UnitOfWork/Registry/UnitOfWorkRegistryBase.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Core/UnitOfWork/Registry/UnitOfWorkRegistryBase.cs
@@ -81,21 +81,25 @@ namespace Riganti.Utils.Infrastructure.Core
         /// <summary>
         /// Gets the unit of work in the current scope.
         /// </summary>
-        public IUnitOfWork GetCurrent()
+        public IUnitOfWork GetCurrent(int ancestorLevel = 0)
         {
             var unitOfWorkStack = GetStack();
             if (unitOfWorkStack == null)
             {
-                return AlternateRegistry.GetCurrent();
+                return AlternateRegistry.GetCurrent(ancestorLevel);
             }
 
-            if (unitOfWorkStack.Count == 0)
+            if (ancestorLevel >= unitOfWorkStack.Count)
             {
                 return null;
             }
-            else
+            else if (ancestorLevel == 0)
             {
                 return unitOfWorkStack.Peek();
+            }
+            else 
+            {
+                return unitOfWorkStack.ToArray()[ancestorLevel];
             }
         }
     }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.DotVVM/DotvvmFacadeExtensions.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.DotVVM/DotvvmFacadeExtensions.cs
@@ -2,6 +2,7 @@
 using Riganti.Utils.Infrastructure.Core;
 using Riganti.Utils.Infrastructure.Services.Facades;
 
+// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure
 {
     public static class DotvvmFacadeExtensions

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.DotVVM/Riganti.Utils.Infrastructure.DotVVM.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.DotVVM/Riganti.Utils.Infrastructure.DotVVM.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.DotVVM</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.DotVVM</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <PackageVersion>2.0.5</PackageVersion>
+    <PackageVersion>2.0.6-multidbcontext</PackageVersion>
     <Company>RIGANTI</Company>
     <Authors>RIGANTI</Authors>
     <Description>Infrastructure project setup for building modern enterprise applications using EntityFramework or Azure Table Storage.</Description>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.DotVVM/Riganti.Utils.Infrastructure.DotVVM.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.DotVVM/Riganti.Utils.Infrastructure.DotVVM.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.DotVVM</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.DotVVM</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <PackageVersion>2.0.7-multidbcontext2</PackageVersion>
+    <PackageVersion>2.0.7-multidbcontext3</PackageVersion>
     <Company>RIGANTI</Company>
     <Authors>RIGANTI</Authors>
     <Description>Infrastructure project setup for building modern enterprise applications using EntityFramework or Azure Table Storage.</Description>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkFirstLevelQueryBase.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkFirstLevelQueryBase.cs
@@ -23,9 +23,9 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
         where TEntity : class
         where TDbContext : DbContext
     {
-        private readonly IUnitOfWorkProvider unitOfWorkProvider;
+        private readonly IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider;
 
-        public EntityFrameworkFirstLevelQueryBase(IUnitOfWorkProvider unitOfWorkProvider)
+        public EntityFrameworkFirstLevelQueryBase(IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider)
         {
             this.unitOfWorkProvider = unitOfWorkProvider;
         }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkFirstLevelQueryBase.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkFirstLevelQueryBase.cs
@@ -19,7 +19,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
     /// <summary>
     /// A base class for first level queries which return filtered entity sets based on user identity or other criteria.
     /// </summary>
-    public class EntityFrameworkFirstLevelQueryBase<TEntity, TDbContext> : IFirstLevelQuery<TEntity> 
+    public class EntityFrameworkFirstLevelQueryBase<TEntity, TDbContext> : IEntityFrameworkFirstLevelQuery<TEntity, TDbContext> 
         where TEntity : class
         where TDbContext : DbContext
     {

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkFirstLevelQueryBase.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkFirstLevelQueryBase.cs
@@ -1,10 +1,27 @@
-﻿using System.Data.Entity;
+﻿using System;
+using System.Data.Entity;
 using System.Linq;
 using Riganti.Utils.Infrastructure.Core;
 
 namespace Riganti.Utils.Infrastructure.EntityFramework
 {
-    public class EntityFrameworkFirstLevelQueryBase<TEntity> : IFirstLevelQuery<TEntity> where TEntity : class
+    /// <summary>
+    /// A base class for first level queries which return filtered entity sets based on user identity or other criteria.
+    /// </summary>
+    public class EntityFrameworkFirstLevelQueryBase<TEntity> : EntityFrameworkFirstLevelQueryBase<TEntity, DbContext>
+        where TEntity : class
+    {
+        public EntityFrameworkFirstLevelQueryBase(IUnitOfWorkProvider unitOfWorkProvider) : base(unitOfWorkProvider)
+        {
+        }
+    }
+
+    /// <summary>
+    /// A base class for first level queries which return filtered entity sets based on user identity or other criteria.
+    /// </summary>
+    public class EntityFrameworkFirstLevelQueryBase<TEntity, TDbContext> : IFirstLevelQuery<TEntity> 
+        where TEntity : class
+        where TDbContext : DbContext
     {
         private readonly IUnitOfWorkProvider unitOfWorkProvider;
 
@@ -13,9 +30,17 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
             this.unitOfWorkProvider = unitOfWorkProvider;
         }
 
-        protected DbContext Context
+        protected TDbContext Context
         {
-            get { return EntityFrameworkUnitOfWork.TryGetDbContext(unitOfWorkProvider); }
+            get
+            {
+                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(unitOfWorkProvider);
+                if (context == null)
+                {
+                    throw new InvalidOperationException("The EntityFrameworkRepository must be used in a unit of work of type EntityFrameworkUnitOfWork!");
+                }
+                return context;
+            }
         }
 
 

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkFirstLevelQueryBase.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkFirstLevelQueryBase.cs
@@ -23,9 +23,22 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
         where TEntity : class
         where TDbContext : DbContext
     {
-        private readonly IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider;
+        private readonly IUnitOfWorkProvider unitOfWorkProvider;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkFirstLevelQueryBase{TEntity, TDbContext}"/> class.
+        /// </summary>
+        /// <param name="unitOfWorkProvider">The unit of work provider.</param>
         public EntityFrameworkFirstLevelQueryBase(IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider)
+            : this((IUnitOfWorkProvider) unitOfWorkProvider)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkFirstLevelQueryBase{TEntity, TDbContext}"/> class.
+        /// </summary>
+        /// <param name="unitOfWorkProvider">The unit of work provider.</param>
+        protected EntityFrameworkFirstLevelQueryBase(IUnitOfWorkProvider unitOfWorkProvider)
         {
             this.unitOfWorkProvider = unitOfWorkProvider;
         }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkPostProcessingQuery.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkPostProcessingQuery.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Riganti.Utils.Infrastructure.Core;
+
+namespace Riganti.Utils.Infrastructure.EntityFramework
+{
+    /// <summary>
+    /// A base implementation of query object in Entity Framework with support of result post processing.
+    /// </summary>
+    public abstract class EntityFrameworkPostProcessingQuery<TQueryableResult, TResult> : EntityFrameworkPostProcessingQuery<TQueryableResult, TResult, DbContext>
+    {
+        protected EntityFrameworkPostProcessingQuery(IUnitOfWorkProvider unitOfWorkProvider)
+            : base(unitOfWorkProvider)
+        {
+        }
+    }
+
+    /// <summary>
+    /// A base implementation of query object in Entity Framework with support of result post processing.
+    /// </summary>
+    public abstract class EntityFrameworkPostProcessingQuery<TQueryableResult, TResult, TDbContext> : QueryBase<TQueryableResult, TResult>
+        where TDbContext : DbContext
+    {
+        private readonly IUnitOfWorkProvider unitOfWorkProvider;
+
+        /// <summary>
+        /// Gets the <see cref="DbContext"/>.
+        /// </summary>
+        protected virtual TDbContext Context
+        {
+            get
+            {
+                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(unitOfWorkProvider);
+                if (context == null)
+                {
+                    throw new InvalidOperationException("The EntityFrameworkQuery must be used in a unit of work of type EntityFrameworkUnitOfWork!");
+                }
+                return context;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkPostProcessingQuery{TQueryableResult, TResult, TDbContext}"/> class.
+        /// </summary>
+        protected EntityFrameworkPostProcessingQuery(IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider)
+            : this((IUnitOfWorkProvider)unitOfWorkProvider)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkPostProcessingQuery{TQueryableResult, TResult, TDbContext}"/> class.
+        /// </summary>
+        protected EntityFrameworkPostProcessingQuery(IUnitOfWorkProvider unitOfWorkProvider)
+        {
+            this.unitOfWorkProvider = unitOfWorkProvider;
+        }
+
+        protected override async Task<IList<TQueryableResult>> ExecuteQueryAsync(IQueryable<TQueryableResult> query, CancellationToken cancellationToken)
+        {
+            return await query.ToListAsync(cancellationToken);
+        }
+
+        public override async Task<int> GetTotalRowCountAsync(CancellationToken cancellationToken)
+        {
+            return await GetQueryable().CountAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkQuery.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkQuery.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data.Entity;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Riganti.Utils.Infrastructure.Core;
 
 namespace Riganti.Utils.Infrastructure.EntityFramework
@@ -11,12 +7,13 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
     /// <summary>
     /// A base implementation of query object in Entity Framework.
     /// </summary>
-    public abstract class EntityFrameworkQuery<TResult> : EntityFrameworkQuery<TResult, TResult>
+    public abstract class EntityFrameworkQuery<TResult> : EntityFrameworkPostProcessingQuery<TResult, TResult>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TResult}"/> class.
         /// </summary>
-        protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider) : base(unitOfWorkProvider)
+        protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider)
+            : base(unitOfWorkProvider)
         {
         }
 
@@ -33,62 +30,24 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
     /// <summary>
     /// A base implementation of query object in Entity Framework.
     /// </summary>
-    public abstract class EntityFrameworkQuery<TQueryableResult, TResult> : EntityFrameworkQuery<TQueryableResult, TResult, DbContext>
-    {
-        protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider) : base(unitOfWorkProvider)
-        {
-        }
-    }
-
-
-    /// <summary>
-    /// A base implementation of query object in Entity Framework.
-    /// </summary>
-    public abstract class EntityFrameworkQuery<TQueryableResult, TResult, TDbContext> : QueryBase<TQueryableResult, TResult>
+    public abstract class EntityFrameworkQuery<TResult, TDbContext> : EntityFrameworkPostProcessingQuery<TResult, TResult, TDbContext>
         where TDbContext : DbContext
     {
-        private readonly IUnitOfWorkProvider unitOfWorkProvider;
-
         /// <summary>
-        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult, TDbContext}"/> class.
-        /// </summary>
-        protected EntityFrameworkQuery(IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider)
-            : this((IUnitOfWorkProvider)unitOfWorkProvider)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult, TDbContext}"/> class.
+        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TResult}"/> class.
         /// </summary>
         protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider)
+            : base(unitOfWorkProvider)
         {
-            this.unitOfWorkProvider = unitOfWorkProvider;
         }
 
         /// <summary>
-        /// Gets the <see cref="DbContext"/>.
+        ///     When overriden in derived class, it allows to modify the materialized results of the query before they are returned
+        ///     to the caller.
         /// </summary>
-        protected virtual TDbContext Context
+        protected override IList<TResult> PostProcessResults(IList<TResult> results)
         {
-            get
-            {
-                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(unitOfWorkProvider);
-                if (context == null)
-                {
-                    throw new InvalidOperationException("The EntityFrameworkQuery must be used in a unit of work of type EntityFrameworkUnitOfWork!");
-                }
-                return context;
-            }
-        }
-
-        protected override async Task<IList<TQueryableResult>> ExecuteQueryAsync(IQueryable<TQueryableResult> query, CancellationToken cancellationToken)
-        {
-            return await query.ToListAsync(cancellationToken);
-        }
-
-        public override async Task<int> GetTotalRowCountAsync(CancellationToken cancellationToken)
-        {
-            return await GetQueryable().CountAsync(cancellationToken);
+            return results;
         }
     }
 }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkQuery.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkQuery.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
 using System.Threading;
@@ -10,12 +11,46 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
     /// <summary>
     /// A base implementation of query object in Entity Framework.
     /// </summary>
-    public abstract class EntityFrameworkQuery<TResult> : QueryBase<TResult>
+    public abstract class EntityFrameworkQuery<TResult> : EntityFrameworkQuery<TResult, TResult>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TResult}"/> class.
+        /// </summary>
+        protected EntityFrameworkQuery(IUnitOfWorkProvider provider) : base(provider)
+        {
+        }
+
+        /// <summary>
+        ///     When overriden in derived class, it allows to modify the materialized results of the query before they are returned
+        ///     to the caller.
+        /// </summary>
+        protected override IList<TResult> PostProcessResults(IList<TResult> results)
+        {
+            return results;
+        }
+    }
+
+    /// <summary>
+    /// A base implementation of query object in Entity Framework.
+    /// </summary>
+    public abstract class EntityFrameworkQuery<TQueryableResult, TResult> : EntityFrameworkQuery<TQueryableResult, TResult, DbContext>
+    {
+        public EntityFrameworkQuery(IUnitOfWorkProvider provider) : base(provider)
+        {
+        }
+    }
+
+
+    /// <summary>
+    /// A base implementation of query object in Entity Framework.
+    /// </summary>
+    public abstract class EntityFrameworkQuery<TQueryableResult, TResult, TDbContext> : QueryBase<TQueryableResult, TResult>
+        where TDbContext : DbContext
     {
         private readonly IUnitOfWorkProvider provider;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TResult}"/> class.
+        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult}"/> class.
         /// </summary>
         protected EntityFrameworkQuery(IUnitOfWorkProvider provider)
         {
@@ -25,9 +60,20 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
         /// <summary>
         /// Gets the <see cref="DbContext"/>.
         /// </summary>
-        protected virtual DbContext Context => EntityFrameworkUnitOfWork.TryGetDbContext(provider);
+        protected virtual TDbContext Context
+        {
+            get
+            {
+                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(provider);
+                if (context == null)
+                {
+                    throw new InvalidOperationException("The EntityFrameworkQuery must be used in a unit of work of type EntityFrameworkUnitOfWork!");
+                }
+                return context;
+            }
+        }
 
-        protected override async Task<IList<TResult>> ExecuteQueryAsync(IQueryable<TResult> query, CancellationToken cancellationToken)
+        protected override async Task<IList<TQueryableResult>> ExecuteQueryAsync(IQueryable<TQueryableResult> query, CancellationToken cancellationToken)
         {
             return await query.ToListAsync(cancellationToken);
         }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkQuery.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkQuery.cs
@@ -47,12 +47,12 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
     public abstract class EntityFrameworkQuery<TQueryableResult, TResult, TDbContext> : QueryBase<TQueryableResult, TResult>
         where TDbContext : DbContext
     {
-        private readonly IUnitOfWorkProvider provider;
+        private readonly IEntityFrameworkUnitOfWorkProvider<TDbContext> provider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult}"/> class.
         /// </summary>
-        protected EntityFrameworkQuery(IUnitOfWorkProvider provider)
+        protected EntityFrameworkQuery(IEntityFrameworkUnitOfWorkProvider<TDbContext> provider)
         {
             this.provider = provider;
         }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkQuery.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkQuery.cs
@@ -16,7 +16,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TResult}"/> class.
         /// </summary>
-        protected EntityFrameworkQuery(IUnitOfWorkProvider provider) : base(provider)
+        protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider) : base(unitOfWorkProvider)
         {
         }
 
@@ -35,7 +35,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
     /// </summary>
     public abstract class EntityFrameworkQuery<TQueryableResult, TResult> : EntityFrameworkQuery<TQueryableResult, TResult, DbContext>
     {
-        public EntityFrameworkQuery(IUnitOfWorkProvider provider) : base(provider)
+        protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider) : base(unitOfWorkProvider)
         {
         }
     }
@@ -47,14 +47,22 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
     public abstract class EntityFrameworkQuery<TQueryableResult, TResult, TDbContext> : QueryBase<TQueryableResult, TResult>
         where TDbContext : DbContext
     {
-        private readonly IEntityFrameworkUnitOfWorkProvider<TDbContext> provider;
+        private readonly IUnitOfWorkProvider unitOfWorkProvider;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult}"/> class.
+        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult, TDbContext}"/> class.
         /// </summary>
-        protected EntityFrameworkQuery(IEntityFrameworkUnitOfWorkProvider<TDbContext> provider)
+        protected EntityFrameworkQuery(IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider)
+            : this((IUnitOfWorkProvider)unitOfWorkProvider)
         {
-            this.provider = provider;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult, TDbContext}"/> class.
+        /// </summary>
+        protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider)
+        {
+            this.unitOfWorkProvider = unitOfWorkProvider;
         }
 
         /// <summary>
@@ -64,7 +72,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
         {
             get
             {
-                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(provider);
+                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(unitOfWorkProvider);
                 if (context == null)
                 {
                     throw new InvalidOperationException("The EntityFrameworkQuery must be used in a unit of work of type EntityFrameworkUnitOfWork!");

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkRepository.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkRepository.cs
@@ -16,7 +16,8 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
     public class EntityFrameworkRepository<TEntity, TKey> : EntityFrameworkRepository<TEntity, TKey, DbContext>
         where TEntity : class, IEntity<TKey>, new()
     {
-        public EntityFrameworkRepository(IUnitOfWorkProvider provider, IDateTimeProvider dateTimeProvider) : base(provider, dateTimeProvider)
+        public EntityFrameworkRepository(IUnitOfWorkProvider unitOfWorkProvider, IDateTimeProvider dateTimeProvider)
+            : base(unitOfWorkProvider, dateTimeProvider)
         {
         }
     }
@@ -28,7 +29,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
         where TEntity : class, IEntity<TKey>, new()
         where TDbContext : DbContext
     {
-        private readonly IEntityFrameworkUnitOfWorkProvider<TDbContext> provider;
+        private readonly IUnitOfWorkProvider unitOfWorkProvider;
         private readonly IDateTimeProvider dateTimeProvider;
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
         {
             get
             {
-                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(provider);
+                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(unitOfWorkProvider);
                 if (context == null)
                 {
                     throw new InvalidOperationException("The EntityFrameworkRepository must be used in a unit of work of type EntityFrameworkUnitOfWork!");
@@ -48,11 +49,19 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EntityFrameworkRepository{TEntity, TKey}"/> class.
+        /// Initializes a new instance of the <see cref="EntityFrameworkRepository{TEntity, TKey, TDbContext}"/> class.
         /// </summary>
-        public EntityFrameworkRepository(IEntityFrameworkUnitOfWorkProvider<TDbContext> provider, IDateTimeProvider dateTimeProvider)
+        public EntityFrameworkRepository(IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider, IDateTimeProvider dateTimeProvider)
+            : this((IUnitOfWorkProvider)unitOfWorkProvider, dateTimeProvider)
         {
-            this.provider = provider;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkRepository{TEntity, TKey, TDbContext}"/> class.
+        /// </summary>
+        protected EntityFrameworkRepository(IUnitOfWorkProvider unitOfWorkProvider, IDateTimeProvider dateTimeProvider)
+        {
+            this.unitOfWorkProvider = unitOfWorkProvider;
             this.dateTimeProvider = dateTimeProvider;
         }
 

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkRepository.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkRepository.cs
@@ -9,10 +9,24 @@ using Riganti.Utils.Infrastructure.Core;
 
 namespace Riganti.Utils.Infrastructure.EntityFramework
 {
+
     /// <summary>
     /// A base implementation of a repository in Entity Framework.
     /// </summary>
-    public class EntityFrameworkRepository<TEntity, TKey> : IRepository<TEntity, TKey> where TEntity : class, IEntity<TKey>, new()
+    public class EntityFrameworkRepository<TEntity, TKey> : EntityFrameworkRepository<TEntity, TKey, DbContext>
+        where TEntity : class, IEntity<TKey>, new()
+    {
+        public EntityFrameworkRepository(IUnitOfWorkProvider provider, IDateTimeProvider dateTimeProvider) : base(provider, dateTimeProvider)
+        {
+        }
+    }
+
+    /// <summary>
+    /// A base implementation of a repository in Entity Framework.
+    /// </summary>
+    public class EntityFrameworkRepository<TEntity, TKey, TDbContext> : IRepository<TEntity, TKey>
+        where TEntity : class, IEntity<TKey>, new()
+        where TDbContext : DbContext
     {
         private readonly IUnitOfWorkProvider provider;
         private readonly IDateTimeProvider dateTimeProvider;
@@ -20,8 +34,18 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
         /// <summary>
         /// Gets the <see cref="DbContext"/>.
         /// </summary>
-        protected DbContext Context => EntityFrameworkUnitOfWork.TryGetDbContext(provider);
-
+        protected virtual TDbContext Context
+        {
+            get
+            {
+                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(provider);
+                if (context == null)
+                {
+                    throw new InvalidOperationException("The EntityFrameworkRepository must be used in a unit of work of type EntityFrameworkUnitOfWork!");
+                }
+                return context;
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkRepository{TEntity, TKey}"/> class.

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkRepository.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkRepository.cs
@@ -24,11 +24,11 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
     /// <summary>
     /// A base implementation of a repository in Entity Framework.
     /// </summary>
-    public class EntityFrameworkRepository<TEntity, TKey, TDbContext> : IRepository<TEntity, TKey>
+    public class EntityFrameworkRepository<TEntity, TKey, TDbContext> : IEntityFrameworkRepository<TEntity, TKey, TDbContext>
         where TEntity : class, IEntity<TKey>, new()
         where TDbContext : DbContext
     {
-        private readonly IUnitOfWorkProvider provider;
+        private readonly IEntityFrameworkUnitOfWorkProvider<TDbContext> provider;
         private readonly IDateTimeProvider dateTimeProvider;
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkRepository{TEntity, TKey}"/> class.
         /// </summary>
-        public EntityFrameworkRepository(IUnitOfWorkProvider provider, IDateTimeProvider dateTimeProvider)
+        public EntityFrameworkRepository(IEntityFrameworkUnitOfWorkProvider<TDbContext> provider, IDateTimeProvider dateTimeProvider)
         {
             this.provider = provider;
             this.dateTimeProvider = dateTimeProvider;

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkUnitOfWork.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkUnitOfWork.cs
@@ -64,7 +64,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkUnitOfWork"/> class.
         /// </summary>
-        public EntityFrameworkUnitOfWork(IUnitOfWorkProvider provider, Func<TDbContext> dbContextFactory, DbContextOptions options)
+        public EntityFrameworkUnitOfWork(IEntityFrameworkUnitOfWorkProvider<TDbContext> provider, Func<TDbContext> dbContextFactory, DbContextOptions options)
         {
             if (options == DbContextOptions.ReuseParentContext)
             {

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkUnitOfWorkProvider.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkUnitOfWorkProvider.cs
@@ -7,14 +7,25 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
     /// <summary>
     /// An implementation of unit of work provider in Entity Framework.
     /// </summary>
-    public class EntityFrameworkUnitOfWorkProvider : UnitOfWorkProviderBase
+    public class EntityFrameworkUnitOfWorkProvider : EntityFrameworkUnitOfWorkProvider<DbContext>
     {
-        private readonly Func<DbContext> dbContextFactory;
+        public EntityFrameworkUnitOfWorkProvider(IUnitOfWorkRegistry registry, Func<DbContext> dbContextFactory) : base(registry, dbContextFactory)
+        {
+        }
+    }
+
+    /// <summary>
+    /// An implementation of unit of work provider in Entity Framework.
+    /// </summary>
+    public class EntityFrameworkUnitOfWorkProvider<TDbContext> : UnitOfWorkProviderBase
+        where TDbContext : DbContext
+    {
+        private readonly Func<TDbContext> dbContextFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkUnitOfWorkProvider"/> class.
         /// </summary>
-        public EntityFrameworkUnitOfWorkProvider(IUnitOfWorkRegistry registry, Func<DbContext> dbContextFactory) : base(registry)
+        public EntityFrameworkUnitOfWorkProvider(IUnitOfWorkRegistry registry, Func<TDbContext> dbContextFactory) : base(registry)
         {
             this.dbContextFactory = dbContextFactory;
         }
@@ -39,9 +50,9 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
         /// <summary>
         /// Creates the unit of work.
         /// </summary>
-        protected virtual EntityFrameworkUnitOfWork CreateUnitOfWork(Func<DbContext> dbContextFactory, DbContextOptions options)
+        protected virtual EntityFrameworkUnitOfWork<TDbContext> CreateUnitOfWork(Func<TDbContext> contextFactory, DbContextOptions options)
         {
-            return new EntityFrameworkUnitOfWork(this, dbContextFactory, options);
+            return new EntityFrameworkUnitOfWork<TDbContext>(this, contextFactory, options);
         }
     }
 }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkUnitOfWorkProvider.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkUnitOfWorkProvider.cs
@@ -17,7 +17,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
     /// <summary>
     /// An implementation of unit of work provider in Entity Framework.
     /// </summary>
-    public class EntityFrameworkUnitOfWorkProvider<TDbContext> : UnitOfWorkProviderBase
+    public class EntityFrameworkUnitOfWorkProvider<TDbContext> : UnitOfWorkProviderBase, IEntityFrameworkUnitOfWorkProvider<TDbContext>
         where TDbContext : DbContext
     {
         private readonly Func<TDbContext> dbContextFactory;

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/IEntityFrameworkFirstLevelQuery.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/IEntityFrameworkFirstLevelQuery.cs
@@ -1,0 +1,14 @@
+﻿using System.Data.Entity;
+using Riganti.Utils.Infrastructure.Core;
+
+namespace Riganti.Utils.Infrastructure.EntityFramework
+{
+    /// <summary>
+    /// Represents a query that returns valid entities which the application should see.
+    /// </summary>
+    // ReSharper disable once UnusedTypeParameter
+    public interface IEntityFrameworkFirstLevelQuery<out TEntity, TDbContext> : IFirstLevelQuery<TEntity>
+        where TDbContext : DbContext
+    {
+    }
+}

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/IEntityFrameworkRepository.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/IEntityFrameworkRepository.cs
@@ -1,0 +1,15 @@
+﻿using System.Data.Entity;
+using Riganti.Utils.Infrastructure.Core;
+
+namespace Riganti.Utils.Infrastructure.EntityFramework
+{
+    /// <summary>
+    /// An interface for repository in Entity Framework.
+    /// </summary>
+    // ReSharper disable once UnusedTypeParameter
+    public interface IEntityFrameworkRepository<TEntity, in TKey, TDbContext> : IRepository<TEntity, TKey>
+        where TEntity : IEntity<TKey>
+        where TDbContext : DbContext
+    {
+    }
+}

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/IEntityFrameworkUnitOfWorkProvider.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/IEntityFrameworkUnitOfWorkProvider.cs
@@ -1,0 +1,14 @@
+﻿using System.Data.Entity;
+using Riganti.Utils.Infrastructure.Core;
+
+namespace Riganti.Utils.Infrastructure.EntityFramework
+{
+    /// <summary>
+    /// An interface for unit of work provider which is responsible for creating and managing unit of work in Entity Framework.
+    /// </summary>
+    // ReSharper disable once UnusedTypeParameter
+    public interface IEntityFrameworkUnitOfWorkProvider<TDbContext> : IUnitOfWorkProvider
+        where TDbContext : DbContext
+    {
+    }
+}

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/Riganti.Utils.Infrastructure.EntityFramework.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/Riganti.Utils.Infrastructure.EntityFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFramework>net461</TargetFramework>
     <AssemblyName>Riganti.Utils.Infrastructure.EntityFramework</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.EntityFramework</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/Riganti.Utils.Infrastructure.EntityFramework.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/Riganti.Utils.Infrastructure.EntityFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFramework>net461</TargetFramework>
     <AssemblyName>Riganti.Utils.Infrastructure.EntityFramework</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.EntityFramework</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkFirstLevelQueryBase.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkFirstLevelQueryBase.cs
@@ -20,7 +20,7 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
     /// <summary>
     /// A base class for first level queries which return filtered entity sets based on user identity or other criteria.
     /// </summary>
-    public class EntityFrameworkFirstLevelQueryBase<TEntity, TDbContext> : IFirstLevelQuery<TEntity>
+    public class EntityFrameworkFirstLevelQueryBase<TEntity, TDbContext> : IEntityFrameworkFirstLevelQuery<TEntity, TDbContext>
         where TEntity : class
         where TDbContext : DbContext
     {

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkFirstLevelQueryBase.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkFirstLevelQueryBase.cs
@@ -24,9 +24,22 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
         where TEntity : class
         where TDbContext : DbContext
     {
-        private readonly IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider;
+        private readonly IUnitOfWorkProvider unitOfWorkProvider;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkFirstLevelQueryBase{TEntity, TDbContext}"/> class.
+        /// </summary>
+        /// <param name="unitOfWorkProvider">The unit of work provider.</param>
         public EntityFrameworkFirstLevelQueryBase(IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider)
+            : this((IUnitOfWorkProvider) unitOfWorkProvider)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkFirstLevelQueryBase{TEntity, TDbContext}"/> class.
+        /// </summary>
+        /// <param name="unitOfWorkProvider">The unit of work provider.</param>
+        protected EntityFrameworkFirstLevelQueryBase(IUnitOfWorkProvider unitOfWorkProvider)
         {
             this.unitOfWorkProvider = unitOfWorkProvider;
         }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkFirstLevelQueryBase.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkFirstLevelQueryBase.cs
@@ -24,9 +24,9 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
         where TEntity : class
         where TDbContext : DbContext
     {
-        private readonly IUnitOfWorkProvider unitOfWorkProvider;
+        private readonly IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider;
 
-        public EntityFrameworkFirstLevelQueryBase(IUnitOfWorkProvider unitOfWorkProvider)
+        public EntityFrameworkFirstLevelQueryBase(IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider)
         {
             this.unitOfWorkProvider = unitOfWorkProvider;
         }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkPostProcessingQuery.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkPostProcessingQuery.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Riganti.Utils.Infrastructure.Core;
+
+namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
+{
+    /// <summary>
+    /// A base implementation of query object in Entity Framework with support of result post processing.
+    /// </summary>
+    public abstract class EntityFrameworkPostProcessingQuery<TQueryableResult, TResult> : EntityFrameworkPostProcessingQuery<TQueryableResult, TResult, DbContext>
+    {
+        protected EntityFrameworkPostProcessingQuery(IUnitOfWorkProvider unitOfWorkProvider)
+            : base(unitOfWorkProvider)
+        {
+        }
+    }
+
+    /// <summary>
+    /// A base implementation of query object in Entity Framework with support of result post processing.
+    /// </summary>
+    public abstract class EntityFrameworkPostProcessingQuery<TQueryableResult, TResult, TDbContext> : QueryBase<TQueryableResult, TResult>
+        where TDbContext : DbContext
+    {
+        private readonly IUnitOfWorkProvider unitOfWorkProvider;
+
+        /// <summary>
+        /// Gets the <see cref="DbContext"/>.
+        /// </summary>
+        protected virtual TDbContext Context
+        {
+            get
+            {
+                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(unitOfWorkProvider);
+                if (context == null)
+                {
+                    throw new InvalidOperationException("The EntityFrameworkQuery must be used in a unit of work of type EntityFrameworkUnitOfWork!");
+                }
+                return context;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkPostProcessingQuery{TQueryableResult, TResult, TDbContext}"/> class.
+        /// </summary>
+        protected EntityFrameworkPostProcessingQuery(IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider)
+            : this((IUnitOfWorkProvider)unitOfWorkProvider)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkPostProcessingQuery{TQueryableResult, TResult, TDbContext}"/> class.
+        /// </summary>
+        protected EntityFrameworkPostProcessingQuery(IUnitOfWorkProvider unitOfWorkProvider)
+        {
+            this.unitOfWorkProvider = unitOfWorkProvider;
+        }
+
+        protected override async Task<IList<TQueryableResult>> ExecuteQueryAsync(IQueryable<TQueryableResult> query, CancellationToken cancellationToken)
+        {
+            return await query.ToListAsync(cancellationToken);
+        }
+
+        public override async Task<int> GetTotalRowCountAsync(CancellationToken cancellationToken)
+        {
+            return await GetQueryable().CountAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkQuery.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkQuery.cs
@@ -16,7 +16,7 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TResult}"/> class.
         /// </summary>
-        protected EntityFrameworkQuery(IUnitOfWorkProvider provider) : base(provider)
+        protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider) : base(unitOfWorkProvider)
         {
         }
 
@@ -35,7 +35,7 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
     /// </summary>
     public abstract class EntityFrameworkQuery<TQueryableResult, TResult> : EntityFrameworkQuery<TQueryableResult, TResult, DbContext>
     {
-        public EntityFrameworkQuery(IUnitOfWorkProvider provider) : base(provider)
+        protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider) : base(unitOfWorkProvider)
         {
         }
     }
@@ -47,14 +47,22 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
     public abstract class EntityFrameworkQuery<TQueryableResult, TResult, TDbContext> : QueryBase<TQueryableResult, TResult>
         where TDbContext : DbContext
     {
-        private readonly IEntityFrameworkUnitOfWorkProvider<TDbContext> provider;
+        private readonly IUnitOfWorkProvider unitOfWorkProvider;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult}"/> class.
+        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult, TDbContext}"/> class.
         /// </summary>
-        protected EntityFrameworkQuery(IEntityFrameworkUnitOfWorkProvider<TDbContext> provider)
+        protected EntityFrameworkQuery(IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider)
+            : this((IUnitOfWorkProvider)unitOfWorkProvider)
         {
-            this.provider = provider;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult, TDbContext}"/> class.
+        /// </summary>
+        protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider)
+        {
+            this.unitOfWorkProvider = unitOfWorkProvider;
         }
 
         /// <summary>
@@ -64,7 +72,7 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
         {
             get
             {
-                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(provider);
+                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(unitOfWorkProvider);
                 if (context == null)
                 {
                     throw new InvalidOperationException("The EntityFrameworkQuery must be used in a unit of work of type EntityFrameworkUnitOfWork!");

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkQuery.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkQuery.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Riganti.Utils.Infrastructure.Core;
 
 namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
@@ -11,12 +7,13 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
     /// <summary>
     /// A base implementation of query object in Entity Framework.
     /// </summary>
-    public abstract class EntityFrameworkQuery<TResult> : EntityFrameworkQuery<TResult, TResult>
+    public abstract class EntityFrameworkQuery<TResult> : EntityFrameworkPostProcessingQuery<TResult, TResult>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TResult}"/> class.
         /// </summary>
-        protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider) : base(unitOfWorkProvider)
+        protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider)
+            : base(unitOfWorkProvider)
         {
         }
 
@@ -33,62 +30,24 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
     /// <summary>
     /// A base implementation of query object in Entity Framework.
     /// </summary>
-    public abstract class EntityFrameworkQuery<TQueryableResult, TResult> : EntityFrameworkQuery<TQueryableResult, TResult, DbContext>
-    {
-        protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider) : base(unitOfWorkProvider)
-        {
-        }
-    }
-
-
-    /// <summary>
-    /// A base implementation of query object in Entity Framework.
-    /// </summary>
-    public abstract class EntityFrameworkQuery<TQueryableResult, TResult, TDbContext> : QueryBase<TQueryableResult, TResult>
+    public abstract class EntityFrameworkQuery<TResult, TDbContext> : EntityFrameworkPostProcessingQuery<TResult, TResult, TDbContext>
         where TDbContext : DbContext
     {
-        private readonly IUnitOfWorkProvider unitOfWorkProvider;
-
         /// <summary>
-        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult, TDbContext}"/> class.
-        /// </summary>
-        protected EntityFrameworkQuery(IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider)
-            : this((IUnitOfWorkProvider)unitOfWorkProvider)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult, TDbContext}"/> class.
+        /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TResult}"/> class.
         /// </summary>
         protected EntityFrameworkQuery(IUnitOfWorkProvider unitOfWorkProvider)
+            : base(unitOfWorkProvider)
         {
-            this.unitOfWorkProvider = unitOfWorkProvider;
         }
 
         /// <summary>
-        /// Gets the <see cref="DbContext"/>.
+        ///     When overriden in derived class, it allows to modify the materialized results of the query before they are returned
+        ///     to the caller.
         /// </summary>
-        protected virtual TDbContext Context
+        protected override IList<TResult> PostProcessResults(IList<TResult> results)
         {
-            get
-            {
-                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(unitOfWorkProvider);
-                if (context == null)
-                {
-                    throw new InvalidOperationException("The EntityFrameworkQuery must be used in a unit of work of type EntityFrameworkUnitOfWork!");
-                }
-                return context;
-            }
-        }
-
-        protected override async Task<IList<TQueryableResult>> ExecuteQueryAsync(IQueryable<TQueryableResult> query, CancellationToken cancellationToken)
-        {
-            return await query.ToListAsync(cancellationToken);
-        }
-
-        public override async Task<int> GetTotalRowCountAsync(CancellationToken cancellationToken)
-        {
-            return await GetQueryable().CountAsync(cancellationToken);
+            return results;
         }
     }
 }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkQuery.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkQuery.cs
@@ -47,12 +47,12 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
     public abstract class EntityFrameworkQuery<TQueryableResult, TResult, TDbContext> : QueryBase<TQueryableResult, TResult>
         where TDbContext : DbContext
     {
-        private readonly IUnitOfWorkProvider provider;
+        private readonly IEntityFrameworkUnitOfWorkProvider<TDbContext> provider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkQuery{TQueryableResult, TResult}"/> class.
         /// </summary>
-        protected EntityFrameworkQuery(IUnitOfWorkProvider provider)
+        protected EntityFrameworkQuery(IEntityFrameworkUnitOfWorkProvider<TDbContext> provider)
         {
             this.provider = provider;
         }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkRepository.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkRepository.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Riganti.Utils.Infrastructure.Core;
 
 namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
@@ -25,11 +24,11 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
     /// <summary>
     /// A base implementation of a repository in Entity Framework.
     /// </summary>
-    public class EntityFrameworkRepository<TEntity, TKey, TDbContext> : IRepository<TEntity, TKey> 
+    public class EntityFrameworkRepository<TEntity, TKey, TDbContext> : IEntityFrameworkRepository<TEntity, TKey, TDbContext>
         where TEntity : class, IEntity<TKey>, new()
         where TDbContext : DbContext
     {
-        private readonly IUnitOfWorkProvider provider;
+        private readonly IEntityFrameworkUnitOfWorkProvider<TDbContext> provider;
         private readonly IDateTimeProvider dateTimeProvider;
 
         /// <summary>
@@ -51,7 +50,7 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkRepository{TEntity, TKey}"/> class.
         /// </summary>
-        public EntityFrameworkRepository(IUnitOfWorkProvider provider, IDateTimeProvider dateTimeProvider)
+        public EntityFrameworkRepository(IEntityFrameworkUnitOfWorkProvider<TDbContext> provider, IDateTimeProvider dateTimeProvider)
         {
             this.provider = provider;
             this.dateTimeProvider = dateTimeProvider;

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkRepository.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkRepository.cs
@@ -16,7 +16,7 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
     public class EntityFrameworkRepository<TEntity, TKey> : EntityFrameworkRepository<TEntity, TKey, DbContext>
         where TEntity : class, IEntity<TKey>, new()
     {
-        public EntityFrameworkRepository(IUnitOfWorkProvider provider, IDateTimeProvider dateTimeProvider) : base(provider, dateTimeProvider)
+        public EntityFrameworkRepository(IUnitOfWorkProvider unitOfWorkProvider, IDateTimeProvider dateTimeProvider) : base(unitOfWorkProvider, dateTimeProvider)
         {
         }
     }
@@ -28,7 +28,7 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
         where TEntity : class, IEntity<TKey>, new()
         where TDbContext : DbContext
     {
-        private readonly IEntityFrameworkUnitOfWorkProvider<TDbContext> provider;
+        private readonly IUnitOfWorkProvider unitOfWorkProvider;
         private readonly IDateTimeProvider dateTimeProvider;
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
         {
             get
             {
-                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(provider);
+                var context = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(unitOfWorkProvider);
                 if (context == null)
                 {
                     throw new InvalidOperationException("The EntityFrameworkRepository must be used in a unit of work of type EntityFrameworkUnitOfWork!");
@@ -48,11 +48,19 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EntityFrameworkRepository{TEntity, TKey}"/> class.
+        /// Initializes a new instance of the <see cref="EntityFrameworkRepository{TEntity, TKey,TDbContext}"/> class.
         /// </summary>
-        public EntityFrameworkRepository(IEntityFrameworkUnitOfWorkProvider<TDbContext> provider, IDateTimeProvider dateTimeProvider)
+        public EntityFrameworkRepository(IEntityFrameworkUnitOfWorkProvider<TDbContext> unitOfWorkProvider, IDateTimeProvider dateTimeProvider)
+            : this((IUnitOfWorkProvider) unitOfWorkProvider, dateTimeProvider)
         {
-            this.provider = provider;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityFrameworkRepository{TEntity, TKey, TDbContext}"/> class.
+        /// </summary>
+        protected EntityFrameworkRepository(IUnitOfWorkProvider unitOfWorkProvider, IDateTimeProvider dateTimeProvider)
+        {
+            this.unitOfWorkProvider = unitOfWorkProvider;
             this.dateTimeProvider = dateTimeProvider;
         }
 

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkUnitOfWork.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkUnitOfWork.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Reflection;
-using Microsoft.EntityFrameworkCore;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Riganti.Utils.Infrastructure.Core;
 
 namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
@@ -63,7 +62,7 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkUnitOfWork"/> class.
         /// </summary>
-        public EntityFrameworkUnitOfWork(IUnitOfWorkProvider provider, Func<TDbContext> dbContextFactory, DbContextOptions options)
+        public EntityFrameworkUnitOfWork(IEntityFrameworkUnitOfWorkProvider<TDbContext> provider, Func<TDbContext> dbContextFactory, DbContextOptions options)
         {
             if (options == DbContextOptions.ReuseParentContext)
             {

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkUnitOfWork.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkUnitOfWork.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,26 +10,67 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
     /// <summary>
     /// An implementation of unit of work in Entity ramework.
     /// </summary>
-    public class EntityFrameworkUnitOfWork : UnitOfWorkBase
+    public class EntityFrameworkUnitOfWork : EntityFrameworkUnitOfWork<DbContext>
+    {
+        public EntityFrameworkUnitOfWork(IUnitOfWorkProvider provider, Func<DbContext> dbContextFactory, DbContextOptions options) : base(provider, dbContextFactory, options)
+        {
+        }
+
+        /// <summary>
+        /// Tries to get the <see cref="DbContext"/> in the current scope.
+        /// </summary>
+        public static DbContext TryGetDbContext(IUnitOfWorkProvider provider)
+        {
+            return TryGetDbContext<DbContext>(provider);
+        }
+
+        /// <summary>
+        /// Tries to get the <see cref="DbContext"/> in the current scope.
+        /// </summary>
+        public static TDbContext TryGetDbContext<TDbContext>(IUnitOfWorkProvider provider)
+            where TDbContext : DbContext
+        {
+            var index = 0;
+            var uow = provider.GetCurrent(index);
+            while (uow != null)
+            {
+                if (uow is EntityFrameworkUnitOfWork<TDbContext> efuow)
+                {
+                    return efuow.Context;
+                }
+
+                index++;
+                uow = provider.GetCurrent(index);
+            }
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// An implementation of unit of work in Entity ramework.
+    /// </summary>
+    public class EntityFrameworkUnitOfWork<TDbContext> : UnitOfWorkBase
+        where TDbContext : DbContext
     {
         private readonly bool hasOwnContext;
 
         /// <summary>
         /// Gets the <see cref="DbContext"/>.
         /// </summary>
-        public DbContext Context { get; private set; }
+        public TDbContext Context { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkUnitOfWork"/> class.
         /// </summary>
-        public EntityFrameworkUnitOfWork(IUnitOfWorkProvider provider, Func<DbContext> dbContextFactory, DbContextOptions options)
+        public EntityFrameworkUnitOfWork(IUnitOfWorkProvider provider, Func<TDbContext> dbContextFactory, DbContextOptions options)
         {
             if (options == DbContextOptions.ReuseParentContext)
             {
-                var parentUow = provider.GetCurrent() as EntityFrameworkUnitOfWork;
-                if (parentUow != null)
+                var parentContext = EntityFrameworkUnitOfWork.TryGetDbContext<TDbContext>(provider);
+                if (parentContext != null)
                 {
-                    this.Context = parentUow.Context;
+                    this.Context = parentContext;
                     return;
                 }
             }
@@ -91,17 +133,5 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
             return hasOwnContext;
         }
 
-        /// <summary>
-        /// Tries to get the <see cref="DbContext"/> in the current scope.
-        /// </summary>
-        public static DbContext TryGetDbContext(IUnitOfWorkProvider provider)
-        {
-            var uow = provider.GetCurrent() as EntityFrameworkUnitOfWork;
-            if (uow == null)
-            {
-                throw new InvalidOperationException("The EntityFrameworkRepository must be used in a unit of work of type EntityFrameworkUnitOfWork!");
-            }
-            return uow.Context;
-        }
     }
 }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkUnitOfWorkProvider.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkUnitOfWorkProvider.cs
@@ -7,14 +7,25 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
     /// <summary>
     /// An implementation of unit of work provider in Entity Framework.
     /// </summary>
-    public class EntityFrameworkUnitOfWorkProvider : UnitOfWorkProviderBase
+    public class EntityFrameworkUnitOfWorkProvider : EntityFrameworkUnitOfWorkProvider<DbContext>
     {
-        private readonly Func<DbContext> dbContextFactory;
+        public EntityFrameworkUnitOfWorkProvider(IUnitOfWorkRegistry registry, Func<DbContext> dbContextFactory) : base(registry, dbContextFactory)
+        {
+        }
+    }
+
+    /// <summary>
+    /// An implementation of unit of work provider in Entity Framework.
+    /// </summary>
+    public class EntityFrameworkUnitOfWorkProvider<TDbContext> : UnitOfWorkProviderBase
+        where TDbContext : DbContext
+    {
+        private readonly Func<TDbContext> dbContextFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityFrameworkUnitOfWorkProvider"/> class.
         /// </summary>
-        public EntityFrameworkUnitOfWorkProvider(IUnitOfWorkRegistry registry, Func<DbContext> dbContextFactory) : base(registry)
+        public EntityFrameworkUnitOfWorkProvider(IUnitOfWorkRegistry registry, Func<TDbContext> dbContextFactory) : base(registry)
         {
             this.dbContextFactory = dbContextFactory;
         }
@@ -39,9 +50,9 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
         /// <summary>
         /// Creates the unit of work.
         /// </summary>
-        protected virtual EntityFrameworkUnitOfWork CreateUnitOfWork(Func<DbContext> dbContextFactory, DbContextOptions options)
+        protected virtual EntityFrameworkUnitOfWork<TDbContext> CreateUnitOfWork(Func<TDbContext> contextFactory, DbContextOptions options)
         {
-            return new EntityFrameworkUnitOfWork(this, dbContextFactory, options);
+            return new EntityFrameworkUnitOfWork<TDbContext>(this, contextFactory, options);
         }
     }
 }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkUnitOfWorkProvider.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkUnitOfWorkProvider.cs
@@ -17,7 +17,7 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
     /// <summary>
     /// An implementation of unit of work provider in Entity Framework.
     /// </summary>
-    public class EntityFrameworkUnitOfWorkProvider<TDbContext> : UnitOfWorkProviderBase
+    public class EntityFrameworkUnitOfWorkProvider<TDbContext> : UnitOfWorkProviderBase, IEntityFrameworkUnitOfWorkProvider<TDbContext>
         where TDbContext : DbContext
     {
         private readonly Func<TDbContext> dbContextFactory;

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/IEntityFrameworkFirstLevelQuery.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/IEntityFrameworkFirstLevelQuery.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Riganti.Utils.Infrastructure.Core;
+
+namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
+{
+    /// <summary>
+    /// Represents a query that returns valid entities which the application should see.
+    /// </summary>
+    // ReSharper disable once UnusedTypeParameter
+    public interface IEntityFrameworkFirstLevelQuery<out TEntity, TDbContext> : IFirstLevelQuery<TEntity>
+        where TDbContext : DbContext
+    {
+    }
+}

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/IEntityFrameworkRepository.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/IEntityFrameworkRepository.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Riganti.Utils.Infrastructure.Core;
+
+namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
+{
+    /// <summary>
+    /// An interface for repository in Entity Framework.
+    /// </summary>
+    // ReSharper disable once UnusedTypeParameter
+    public interface IEntityFrameworkRepository<TEntity, in TKey, TDbContext> : IRepository<TEntity, TKey>
+        where TEntity : IEntity<TKey>
+        where TDbContext : DbContext
+    {
+    }
+}

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/IEntityFrameworkUnitOfWorkProvider.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/IEntityFrameworkUnitOfWorkProvider.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Riganti.Utils.Infrastructure.Core;
+
+namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
+{
+    /// <summary>
+    /// An interface for unit of work provider which is responsible for creating and managing unit of work in Entity Framework.
+    /// </summary>
+    // ReSharper disable once UnusedTypeParameter
+    public interface IEntityFrameworkUnitOfWorkProvider<TDbContext> : IUnitOfWorkProvider
+        where TDbContext : DbContext
+    {
+    }
+}

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/Riganti.Utils.Infrastructure.EntityFrameworkCore.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/Riganti.Utils.Infrastructure.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>Riganti.Utils.Infrastructure.EntityFrameworkCore</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.EntityFrameworkCore</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/Riganti.Utils.Infrastructure.EntityFrameworkCore.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/Riganti.Utils.Infrastructure.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>Riganti.Utils.Infrastructure.EntityFrameworkCore</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.EntityFrameworkCore</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Amazon.SES/Mailing/AmazonSESMailSender.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Amazon.SES/Mailing/AmazonSESMailSender.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Amazon.Runtime;
 using Amazon.SimpleEmail;
 using Amazon.SimpleEmail.Model;
 using Riganti.Utils.Infrastructure.Services.Mailing;

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Amazon.SES/Riganti.Utils.Infrastructure.Services.Amazon.SES.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Amazon.SES/Riganti.Utils.Infrastructure.Services.Amazon.SES.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Amazon.SES</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Amazon.SES</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Amazon.SES/Riganti.Utils.Infrastructure.Services.Amazon.SES.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Amazon.SES/Riganti.Utils.Infrastructure.Services.Amazon.SES.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Amazon.SES</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Amazon.SES</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Amazon.SES/Riganti.Utils.Infrastructure.Services.Amazon.SES.csproj.DotSettings
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Amazon.SES/Riganti.Utils.Infrastructure.Services.Amazon.SES.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=mailing/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Azure/Riganti.Utils.Infrastructure.Services.Azure.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Azure/Riganti.Utils.Infrastructure.Services.Azure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Azure</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Azure</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Azure/Riganti.Utils.Infrastructure.Services.Azure.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Azure/Riganti.Utils.Infrastructure.Services.Azure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Azure</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Azure</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -5,6 +5,7 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Riganti.Utils.Infrastructure.Core;
 
+// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.Services.Logging
 {
     public class ApplicationInsightsLogger : LoggerBase

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights/IApplicationInsightsSettings.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights/IApplicationInsightsSettings.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.Services.Logging
 {
     public interface IApplicationInsightsSettings

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights/Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights/Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights/Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights/Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Logging.ApplicationInsights</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.Email/EmailLogger.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.Email/EmailLogger.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Riganti.Utils.Infrastructure.Core;
 using Riganti.Utils.Infrastructure.Services.Mailing;
 
+// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.Services.Logging
 {
     public class EmailLogger : LoggerBase

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.Email/Riganti.Utils.Infrastructure.Services.Logging.Email.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.Email/Riganti.Utils.Infrastructure.Services.Logging.Email.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Logging.Email</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Logging.Email</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.Email/Riganti.Utils.Infrastructure.Services.Logging.Email.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging.Email/Riganti.Utils.Infrastructure.Services.Logging.Email.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Logging.Email</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Logging.Email</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging/Riganti.Utils.Infrastructure.Services.Logging.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging/Riganti.Utils.Infrastructure.Services.Logging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Logging</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Logging</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging/Riganti.Utils.Infrastructure.Services.Logging.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Logging/Riganti.Utils.Infrastructure.Services.Logging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Logging</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Logging</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing/Riganti.Utils.Infrastructure.Services.Mailing.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing/Riganti.Utils.Infrastructure.Services.Mailing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Mailing</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Mailing</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing/Riganti.Utils.Infrastructure.Services.Mailing.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing/Riganti.Utils.Infrastructure.Services.Mailing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Mailing</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Mailing</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.SendGrid/Riganti.Utils.Infrastructure.Services.SendGrid.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.SendGrid/Riganti.Utils.Infrastructure.Services.SendGrid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.SendGrid</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.SendGrid</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.SendGrid/Riganti.Utils.Infrastructure.Services.SendGrid.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.SendGrid/Riganti.Utils.Infrastructure.Services.SendGrid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.SendGrid</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.SendGrid</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Smtp/Riganti.Utils.Infrastructure.Services.Smtp.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Smtp/Riganti.Utils.Infrastructure.Services.Smtp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Smtp</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Smtp</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Smtp/Riganti.Utils.Infrastructure.Services.Smtp.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Smtp/Riganti.Utils.Infrastructure.Services.Smtp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Smtp</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Smtp</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services/Riganti.Utils.Infrastructure.Services.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services/Riganti.Utils.Infrastructure.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services/Riganti.Utils.Infrastructure.Services.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services/Riganti.Utils.Infrastructure.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.SystemWeb/Riganti.Utils.Infrastructure.SystemWeb.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.SystemWeb/Riganti.Utils.Infrastructure.SystemWeb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.7-multidbcontext2</VersionPrefix>
+    <VersionPrefix>2.0.7-multidbcontext3</VersionPrefix>
     <TargetFramework>net461</TargetFramework>
     <AssemblyName>Riganti.Utils.Infrastructure.SystemWeb</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.SystemWeb</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.SystemWeb/Riganti.Utils.Infrastructure.SystemWeb.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.SystemWeb/Riganti.Utils.Infrastructure.SystemWeb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6-multidbcontext</VersionPrefix>
     <TargetFramework>net461</TargetFramework>
     <AssemblyName>Riganti.Utils.Infrastructure.SystemWeb</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.SystemWeb</PackageId>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.SystemWeb/Services/Logging/DefaultWebAdditionalDataProvider.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.SystemWeb/Services/Logging/DefaultWebAdditionalDataProvider.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Web;
 
+// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.Services.Logging
 {
     public class DefaultWebAdditionalDataProvider : IAdditionalDataProvider

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.SystemWeb/Services/Mailing/SmtpClientMailSender.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.SystemWeb/Services/Mailing/SmtpClientMailSender.cs
@@ -1,6 +1,7 @@
 using System.Net.Mail;
 using System.Threading.Tasks;
 
+// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.Services.Mailing
 {
     public class SmtpClientMailSender : IMailSender

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.SystemWeb/UnitOfWork/Registry/HttpContextUnitOfWorkRegistry.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.SystemWeb/UnitOfWork/Registry/HttpContextUnitOfWorkRegistry.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Web;
 
+// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.Core
 {
     /// <summary>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/CoreNamespacesTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/CoreNamespacesTests.cs
@@ -19,6 +19,7 @@ namespace Riganti.Utils.Infrastructure.Core.Tests
             var incorrectTypes = infrastructureCoreAssembly.GetTypes()
                                                           .Where(t => t.Namespace != correctNameSpace)
                                                           .Where(t => t.Namespace != "JetBrains.Profiler.Windows.Core.Instrumentation") //dotcover continuous testing add this namespace at runtime 
+                                                          .Where(t => !t.Name.StartsWith("<>"))
                                                           .Select(t => t.FullName)
                                                           .ToArray();
 

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/UnitOfWork/Provider/UnitOfWorkProviderBaseTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/UnitOfWork/Provider/UnitOfWorkProviderBaseTests.cs
@@ -10,13 +10,13 @@ namespace Riganti.Utils.Infrastructure.Core.Tests.UnitOfWork.Provider
         {
             var unitOfWorkRegistryMock = new Mock<IUnitOfWorkRegistry>();
             var unitOfWork = new Mock<IUnitOfWork>().Object;
-            unitOfWorkRegistryMock.Setup(unitOfWorkRegistry => unitOfWorkRegistry.GetCurrent()).Returns(unitOfWork);
+            unitOfWorkRegistryMock.Setup(unitOfWorkRegistry => unitOfWorkRegistry.GetCurrent(0)).Returns(unitOfWork);
             var unitOfWorkProviderSUT = CreateUnitOfWorkProviderStub(unitOfWorkRegistry: unitOfWorkRegistryMock.Object);
 
             var unitOfWorkProviderCurrentUnitOfWork = unitOfWorkProviderSUT.GetCurrent();
 
             Assert.Same(unitOfWork, unitOfWorkProviderCurrentUnitOfWork);
-            unitOfWorkRegistryMock.Verify(unitOfWorkRegistry => unitOfWorkRegistry.GetCurrent(), Times.Once);
+            unitOfWorkRegistryMock.Verify(unitOfWorkRegistry => unitOfWorkRegistry.GetCurrent(0), Times.Once);
         }
 
         [Fact]

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/Repository/EntityFrameworkUnitOfProviderTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/Repository/EntityFrameworkUnitOfProviderTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Riganti.Utils.Infrastructure.Core;
+using Xunit;
+
+namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.Repository
+{
+    public class EntityFrameworkUnitOfProviderTests
+    {
+
+        public class CustomDbContext1 : DbContext
+        {
+        }
+
+        public class CustomDbContext2 : DbContext
+        {
+        }
+
+        [Fact]
+        public void NestedDbContexts()
+        {
+            var registry = new ThreadLocalUnitOfWorkRegistry();
+            var uowp1 = new EntityFrameworkUnitOfWorkProvider<CustomDbContext1>(registry, () => new CustomDbContext1());
+            var uowp2 = new EntityFrameworkUnitOfWorkProvider<CustomDbContext2>(registry, () => new CustomDbContext2());
+
+            using (var uow1 = uowp1.Create())
+            {
+                using (var uow2 = uowp2.Create())
+                {
+                    var current = registry.GetCurrent(0);
+                    Assert.Equal(uow2, current);
+
+                    var parent = registry.GetCurrent(1);
+                    Assert.Equal(uow1, parent);
+
+                    var inner = EntityFrameworkUnitOfWork.TryGetDbContext<CustomDbContext2>(uowp2);
+                    Assert.Equal(inner, ((EntityFrameworkUnitOfWork<CustomDbContext2>)uow2).Context);
+
+                    var outer = EntityFrameworkUnitOfWork.TryGetDbContext<CustomDbContext1>(uowp1);
+                    Assert.Equal(outer, ((EntityFrameworkUnitOfWork<CustomDbContext1>)uow1).Context);
+                }
+            }
+        }
+
+    }
+}

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
@@ -162,17 +162,15 @@ namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.UnitOfWork
         }
 
         [Fact]
-        public void TryGetDbContext_UnitOfWorkRegistryHasNotUnitOfWork_ThrowsException()
+        public void TryGetDbContext_UnitOfWorkRegistryHasNotUnitOfWork_ReturnsNull()
         {
             var dbContext = new Mock<DbContext>().Object;
             Func<DbContext> dbContextFactory = () => dbContext;
             var unitOfWorkRegistryStub = new ThreadLocalUnitOfWorkRegistry();
             var unitOfWorkProvider = new EntityFrameworkUnitOfWorkProvider(unitOfWorkRegistryStub, dbContextFactory);
             
-            Action sut = () => EntityFrameworkUnitOfWork.TryGetDbContext(unitOfWorkProvider);
-
-            var invalidOperationException = Assert.Throws<InvalidOperationException>(sut);
-            Assert.Contains("The EntityFrameworkRepository must be used in a unit of work of type EntityFrameworkUnitOfWork!", invalidOperationException.Message);
+            var value = EntityFrameworkUnitOfWork.TryGetDbContext(unitOfWorkProvider);
+            Assert.Null(value);
         }
     }
 }

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Repository/EntityFrameworkRepositoryTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Repository/EntityFrameworkRepositoryTests.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Moq;
-using Riganti.Utils.Infrastructure.Core;
-using Riganti.Utils.Infrastructure.EntityFrameworkCore;
-using Xunit;
-
+﻿// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.Repository
 {
     public class EntityFrameworkRepositoryTests

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Repository/EpisodeEntity.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Repository/EpisodeEntity.cs
@@ -1,5 +1,6 @@
 ﻿using Riganti.Utils.Infrastructure.Core;
 
+// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.Repository
 {
     public class EpisodeEntity : IEntity<int>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Repository/QuoteEntity.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Repository/QuoteEntity.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Riganti.Utils.Infrastructure.Core;
 
+// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.Repository
 {
   public class QuoteEntity : IEntity<int>, ISoftDeleteEntity

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Repository/YesMinisterDbContext.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Repository/YesMinisterDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
+// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.Repository
 {
     public class YesMinisterDbContext : DbContext

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
@@ -8,6 +8,7 @@ using Riganti.Utils.Infrastructure.Core;
 using Riganti.Utils.Infrastructure.EntityFrameworkCore;
 using Xunit;
 
+// ReSharper disable once CheckNamespace
 namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.UnitOfWork
 {
     public class EntityFrameworkUnitOfWorkTests

--- a/src/Infrastructure/clean-bin-obj-packages.cmd
+++ b/src/Infrastructure/clean-bin-obj-packages.cmd
@@ -1,0 +1,2 @@
+for /d /r . %%d in (bin,obj,Packages) do @if exist "%%d" rd /s/q "%%d"
+pause

--- a/src/Infrastructure/clean-bin-obj.cmd
+++ b/src/Infrastructure/clean-bin-obj.cmd
@@ -1,0 +1,2 @@
+for /d /r . %%d in (bin,obj) do @if exist "%%d" rd /s/q "%%d"
+pause


### PR DESCRIPTION
The `TDbContext` generic parameter was added to the unit of work, repositories and queries to support multiple types of `DbContext`.
The `EntityFrameworkUnitOfWork.TryGetDbContext` method was adjusted to support nested unit of works with different `DbContext` types.

The original classes without the `TDbContext` parameter were preserved for the single database applications so there should not be breaking changes.