### PR TITLE
Solve build warnings

### DIFF
--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Logging.ApplicationInsights/Riganti.Utils.Infrastructure.Logging.ApplicationInsights.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Logging.ApplicationInsights/Riganti.Utils.Infrastructure.Logging.ApplicationInsights.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0-beta2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Azure.TableStorage.Tests/Riganti.Utils.Infrastructure.Azure.TableStorage.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Azure.TableStorage.Tests/Riganti.Utils.Infrastructure.Azure.TableStorage.Tests.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Azure.TableStorage.Tests/Riganti.Utils.Infrastructure.Azure.TableStorage.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Azure.TableStorage.Tests/Riganti.Utils.Infrastructure.Azure.TableStorage.Tests.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.7.1" />
+    <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Riganti.Utils.Infrastructure.Core.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Riganti.Utils.Infrastructure.Core.Tests.csproj
@@ -36,8 +36,6 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="moq" Version="4.7.1" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Riganti.Utils.Infrastructure.Core.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Riganti.Utils.Infrastructure.Core.Tests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="moq" Version="4.7.1" />
+    <PackageReference Include="moq" Version="4.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Riganti.Utils.Infrastructure.Core.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Riganti.Utils.Infrastructure.Core.Tests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="moq" Version="4.9.0" />
+    <PackageReference Include="moq" Version="4.7.145" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="EntityFramework" Version="6.1.3" />
-    <PackageReference Include="moq" Version="4.7.1" />
+    <PackageReference Include="moq" Version="4.9.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="EntityFramework" Version="6.1.3" />
-    <PackageReference Include="moq" Version="4.9.0" />
+    <PackageReference Include="moq" Version="4.7.145" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.0" />
-    <PackageReference Include="moq" Version="4.7.1" />
+    <PackageReference Include="moq" Version="4.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.0" />
-    <PackageReference Include="moq" Version="4.9.0" />
+    <PackageReference Include="moq" Version="4.7.145" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Mailing.Tests/Riganti.Utils.Infrastructure.Services.Mailing.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Mailing.Tests/Riganti.Utils.Infrastructure.Services.Mailing.Tests.csproj
@@ -25,12 +25,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="moq" Version="4.7.1" />
+    <PackageReference Include="moq" Version="4.9.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Mailing.Tests/Riganti.Utils.Infrastructure.Services.Mailing.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Mailing.Tests/Riganti.Utils.Infrastructure.Services.Mailing.Tests.csproj
@@ -25,13 +25,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="moq" Version="4.9.0" />
+    <PackageReference Include="moq" Version="4.7.145" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Tests/Riganti.Utils.Infrastructure.Services.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Tests/Riganti.Utils.Infrastructure.Services.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -12,7 +12,7 @@
     <PackageReference Include="AutoMapper" Version="5.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.7.1" />
+    <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.0" />

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Tests/Riganti.Utils.Infrastructure.Services.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Tests/Riganti.Utils.Infrastructure.Services.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="AutoMapper" Version="5.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.0" />

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Tests/Riganti.Utils.Infrastructure.Services.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Tests/Riganti.Utils.Infrastructure.Services.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="6.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.3" />
+    <PackageReference Include="AutoMapper" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.7.127" />
+    <PackageReference Include="Moq" Version="4.7.1" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Solved build warnings by consolidating and updating some nuget packages and by removing unnecessary references.