### PR TITLE
fix overrides in EFCore and EF UOW

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Change Log
 
-## 2.2.5
-- Fix insidious bug in EFCore and EF unit of work which appear after added async methods to facades(v2.2.0). In `CrudFacadeBase` inside in `SaveAsync` is `uow.CommitAsync(cancellationToken)` and no matter what it calls `Context.SaveChanges` although it will be called in parent `uow` scope. **So this fix does cause breaking change.**
+## 2.3.0
+- **Fix with breaking change!** Fixed insidious bug in EFCore and EF unit of work which appeared after async methods were added into facades (v2.2.0). In class `CrudFacadeBase` there is async method `SaveAsync` which calls `uow.CommitAsync(cancellationToken)`. If you call this in nested `uow` scope then it will raise `Context.SaveChanges` and that's wrong.
 
 ## 2.2.4
  Add asynchronous metod in `DotvvmFacadeExtensions`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## 2.3.0
-- **Fix with breaking change!** Fixed insidious bug in EFCore and EF unit of work which appeared after async methods were added into facades (v2.2.0). In class `CrudFacadeBase` there is async method `SaveAsync` which calls `uow.CommitAsync(cancellationToken)`. If you call this in nested `uow` scope then it will raise `Context.SaveChanges` and that's wrong.
+- **Fix with breaking change!** Fixed insidious bug in EFCore and EF unit of work which appeared after async methods were added into facades (v2.2.0). In class `CrudFacadeBase` there is async method `SaveAsync` which calls `uow.CommitAsync(cancellationToken)`. If you called this in nested `uow` scope then it would raise `Context.SaveChanges` and that was wrong.
 
 ## 2.2.4
  Add asynchronous metod in `DotvvmFacadeExtensions`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 2.2.5
+- Fix insidious bug in EFCore and EF unit of work which appear after added async methods to facades(v2.2.0). In `CrudFacadeBase` inside in `SaveAsync` is `uow.CommitAsync(cancellationToken)` and no matter what it calls `Context.SaveChanges` although it will be in parent `uow` scope. **So this fix does cause breaking change.**
+
 ## 2.2.4
  Add asynchronous metod in `DotvvmFacadeExtensions`.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## 2.2.5
-- Fix insidious bug in EFCore and EF unit of work which appear after added async methods to facades(v2.2.0). In `CrudFacadeBase` inside in `SaveAsync` is `uow.CommitAsync(cancellationToken)` and no matter what it calls `Context.SaveChanges` although it will be in parent `uow` scope. **So this fix does cause breaking change.**
+- Fix insidious bug in EFCore and EF unit of work which appear after added async methods to facades(v2.2.0). In `CrudFacadeBase` inside in `SaveAsync` is `uow.CommitAsync(cancellationToken)` and no matter what it calls `Context.SaveChanges` although it will be called in parent `uow` scope. **So this fix does cause breaking change.**
 
 ## 2.2.4
  Add asynchronous metod in `DotvvmFacadeExtensions`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## 2.3.0
-- **Fix with breaking change!** Fixed insidious bug in EFCore and EF unit of work which appeared after async methods were added into facades (v2.2.0). In class `CrudFacadeBase` there is async method `SaveAsync` which calls `uow.CommitAsync(cancellationToken)`. If you called this in nested `uow` scope then it would raise `Context.SaveChanges` and that was wrong.
+- **Fix with breaking change!** Fixed insidious bug in EFCore and EF unit of work which appeared after async methods were added into facades (v2.2.0). In class `CrudFacadeBase` there is async method `SaveAsync` which calls `uow.CommitAsync(cancellationToken)`. If you called this in nested `uow` scope then it would raise `Context.SaveChanges` and that was wrong. PR [#43](https://github.com/riganti/infrastructure/pull/43)
 
 ## 2.2.4
  Add asynchronous metod in `DotvvmFacadeExtensions`.

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Core/UnitOfWork/UnitOfWorkBase.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Core/UnitOfWork/UnitOfWorkBase.cs
@@ -31,7 +31,7 @@ namespace Riganti.Utils.Infrastructure.Core
             await CommitAsync(default(CancellationToken));
         }
 
-        public async Task CommitAsync(CancellationToken cancellationToken)
+        public virtual async Task CommitAsync(CancellationToken cancellationToken)
         {
             await CommitAsyncCore(cancellationToken);
 

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkUnitOfWork.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/EntityFrameworkUnitOfWork.cs
@@ -110,23 +110,25 @@ namespace Riganti.Utils.Infrastructure.EntityFramework
                 TryRequestParentCommit();
             }
         }
-
         /// <summary>
         /// Commits this instance when we have to. Skip and request from parent, if we don't own the context.
         /// </summary>
-        public override Task CommitAsync()
+        public override Task CommitAsync(CancellationToken cancellationToken)
         {
             if (HasOwnContext())
             {
                 CommitPending = false;
-                return base.CommitAsync();
-            }
-            else
-            {
-                TryRequestParentCommit();
+                return base.CommitAsync(cancellationToken);
             }
 
+            TryRequestParentCommit();
+
             return Task.CompletedTask;
+        }
+
+        public override async Task CommitAsync()
+        {
+            await CommitAsync(default(CancellationToken));
         }
 
         /// <inheritdoc cref="ICheckChildCommitUnitOfWork.RequestCommit" />

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkUnitOfWork.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/EntityFrameworkUnitOfWork.cs
@@ -113,19 +113,22 @@ namespace Riganti.Utils.Infrastructure.EntityFrameworkCore
         /// <summary>
         /// Commits this instance when we have to. Skip and request from parent, if we don't own the context.
         /// </summary>
-        public override Task CommitAsync()
+        public override Task CommitAsync(CancellationToken cancellationToken)
         {
             if (HasOwnContext())
             {
                 CommitPending = false;
-                return base.CommitAsync();
-            }
-            else
-            {
-                TryRequestParentCommit();
+                return base.CommitAsync(cancellationToken);
             }
 
+            TryRequestParentCommit();
+
             return Task.CompletedTask;
+        }
+
+        public override async Task CommitAsync()
+        {
+            await CommitAsync(default(CancellationToken));
         }
 
         /// <inheritdoc cref="ICheckChildCommitUnitOfWork.RequestCommit" />

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
@@ -338,7 +338,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.UnitOfWork
         }
 
         [Fact]
-        public async Task Call_CommitAsync_With_Token_In_Nested_Uow_SavesChanges_In_Parent_Uow()
+        public async Task CommitAsync_WithTokenInNestedUow_SavedChangesInParentUow()
         {
             var dbContext = new Mock<DbContext>();
             Func<DbContext> dbContextFactory = () => dbContext.Object;
@@ -366,7 +366,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.UnitOfWork
         }
 
         [Fact]
-        public async Task Call_CommitAsync_In_Nested_Uow_SavesChanges_In_Parent_Uow()
+        public async Task CommitAsync_InNestedUow_SavedChangesInParentUow()
         {
             var dbContext = new Mock<DbContext>();
             Func<DbContext> dbContextFactory = () => dbContext.Object;

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
@@ -392,11 +392,5 @@ namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.UnitOfWork
                 dbContext.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
             }
         }
-
-
-        public class SaveChangesException : Exception
-        {
-
-        }
     }
 }

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
@@ -356,14 +356,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.UnitOfWork
                     await nested.CommitAsync(new CancellationToken());
                 }
 
-                try
-                {
-                    await uow.CommitAsync(new CancellationToken());
-                }
-                catch
-                {
-                    // ignored
-                }
+                await Assert.ThrowsAsync<SaveChangesException>(() => uow.CommitAsync(new CancellationToken()));
             }
         }
 
@@ -386,14 +379,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.UnitOfWork
                     await nested.CommitAsync();
                 }
 
-                try
-                {
-                    await uow.CommitAsync();
-                }
-                catch
-                {
-                    // ignored
-                }
+                await Assert.ThrowsAsync<SaveChangesException>(() => uow.CommitAsync(new CancellationToken()));
             }
         }
 

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
@@ -338,7 +338,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.UnitOfWork
         }
 
         [Fact]
-        public async Task CommitAsync_WithTokenInNestedUow_SavedChangesInParentUow()
+        public async Task CommitAsync_WithCancellationTokenInNestedUow_SavedChangesInParentUow()
         {
             var dbContext = new Mock<DbContext>();
             Func<DbContext> dbContextFactory = () => dbContext.Object;
@@ -366,7 +366,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.UnitOfWork
         }
 
         [Fact]
-        public async Task CommitAsync_InNestedUow_SavedChangesInParentUow()
+        public async Task CommitAsync_WithoutCancellationTokenInNestedUow_SavedChangesInParentUow()
         {
             var dbContext = new Mock<DbContext>();
             Func<DbContext> dbContextFactory = () => dbContext.Object;

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/UnitOfWork/EntityFrameworkUnitOfWorkTests.cs
@@ -379,7 +379,7 @@ namespace Riganti.Utils.Infrastructure.EntityFramework.Tests.UnitOfWork
                     await nested.CommitAsync();
                 }
 
-                await Assert.ThrowsAsync<SaveChangesException>(() => uow.CommitAsync(new CancellationToken()));
+                await Assert.ThrowsAsync<SaveChangesException>(() => uow.CommitAsync());
             }
         }
 


### PR DESCRIPTION
Fix insidious bug in EFCore and EF unit of work which appear after added async methods to facades(v2.2.0). In `CrudFacadeBase ` inside in `SaveAsync` is `uow.CommitAsync(cancellationToken)` and no matter what it calls `Context.SaveChanges` although it will be called in parent uow scope.
```
using(var uow = UnitOfWorkProvider.Create())
{
  using(var childUow = UnitOfWorkProvider.Create())
  {
    await childUow.CommitAsync(new CancellationToken()) //this call SaveChanges, but it can not
  }
  await uow.CommitAsync(new CancellationToken()) //this should call SaveChanges
}

//this same code, but without CancellationToken, behaves correctly
using(var uow = UnitOfWorkProvider.Create())
{
  using(var childUow = UnitOfWorkProvider.Create())
  {
    await childUow.CommitAsync() //here do nothing
  }
  await uow.CommitAsync() //this call SaveChanges
}
```