### PR TITLE
Adds sorting by nested sort criteria

### DIFF
--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/CustomerTestData.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/CustomerTestData.cs
@@ -6,5 +6,12 @@ namespace Riganti.Utils.Infrastructure.Core.Tests
         public string LastName { get; set; }
         public int CategoryId { get; set; }
         public bool? Truthful { get; set; }
+        public Address Address { get; set; }
+    }
+
+    public class Address
+    {
+        public string Street { get; set; }
+        public string City { get; set; }
     }
 }

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Query/QueryBaseTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Query/QueryBaseTests.cs
@@ -84,6 +84,19 @@ namespace Riganti.Utils.Infrastructure.Core.Tests.Query
         }
 
         [Fact]
+        public void AddSortCriteriaString_SortUsingNestedEntity()
+        {
+            var querySUT = CreateQueryBaseStub();
+            Expression<Func<CustomerTestData, string>> sortExpression = customer => customer.Address.City;
+            querySUT.AddSortCriteria($"{nameof(Address)}.{nameof(Address.City)}", SortDirection.Descending);
+
+            var queryResult = querySUT.Execute();
+
+            Assert.Equal(customers.OrderByDescending(sortExpression), queryResult);
+        }
+        
+        
+        [Fact]
         public void GetTotalRowCount_ReturnsDataCount()
         {
             var querySUT = CreateQueryBaseStub();

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Query/QueryTestsBase.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Query/QueryTestsBase.cs
@@ -11,7 +11,12 @@ namespace Riganti.Utils.Infrastructure.Core.Tests.Query
                 FirstName = "Humphrey",
                 LastName = "Appleby",
                 CategoryId = 2,
-                Truthful = false
+                Truthful = false,
+                Address = new Address()
+                {
+                    City = "Small City",
+                    Street = "Short Street"
+                }
             },
             new CustomerTestData()
             {
@@ -22,7 +27,7 @@ namespace Riganti.Utils.Infrastructure.Core.Tests.Query
                 Address = new Address()
                 {
                     City = "New York",
-                    Street = "BigStreet"
+                    Street = "Big Street"
                 }
             },
             new CustomerTestData()
@@ -34,7 +39,7 @@ namespace Riganti.Utils.Infrastructure.Core.Tests.Query
                 Address = new Address()
                 {
                     City = "Prague",
-                    Street = "BigStreet"
+                    Street = "Big Street"
                 }
             }
         }.AsQueryable();

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Query/QueryTestsBase.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Query/QueryTestsBase.cs
@@ -18,14 +18,24 @@ namespace Riganti.Utils.Infrastructure.Core.Tests.Query
                 FirstName = "Jim",
                 LastName = "Hacker",
                 CategoryId = 1,
-                Truthful = false
+                Truthful = false,
+                Address = new Address()
+                {
+                    City = "New York",
+                    Street = "BigStreet"
+                }
             },
             new CustomerTestData()
             {
                 FirstName = "Bernard",
                 LastName = "Woolley",
                 CategoryId = 2,
-                Truthful = true
+                Truthful = true,
+                Address = new Address()
+                {
+                    City = "Prague",
+                    Street = "BigStreet"
+                }
             }
         }.AsQueryable();
     }


### PR DESCRIPTION
In current version queries don't support sorting by nested sort criteria. For example:
```csharp
public class User{
    public Address Address {get;set;};
}
public class Address{
    string Street {get;set;}
}

var query = new Query<User>().AddSortCriteria("Address.Street")
query.Execute(); //Throws exception
```

This PR fixes the issue.

resolves #45 


