### PR TITLE
Automapper update and .net standard update

### DIFF
--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AspNetCore/Riganti.Utils.Infrastructure.AspNetCore.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AspNetCore/Riganti.Utils.Infrastructure.AspNetCore.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.AspNetCore</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.AspNetCore</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -24,7 +23,7 @@
     <LangVersion>7.1</LangVersion> 
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <PropertyGroup>
     <DefineConstants>$(DefineConstants);DotNetCore</DefineConstants>
   </PropertyGroup>
 

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper.EntityFramework/EntityFrameworkExtensions.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper.EntityFramework/EntityFrameworkExtensions.cs
@@ -96,6 +96,7 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
                 Expression<Func<TSource, ICollection<TSourceItem>>> sourceCollectionSelector,
                 Func<TSourceItem, TKey> sourceKeySelector,
                 Func<TDestinationItem, TKey> destinationKeySelector,
+                IMapper mapper,
                 Func<TSourceItem, TDestinationItem> createFunction = null,
                 Action<TSourceItem, TDestinationItem> updateFunction = null,
                 Action<TDestinationItem> removeFunction = null,
@@ -114,7 +115,7 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
                 };
             }
 
-            Extensions.SyncCollectionByKey(config, sourceCollectionSelector, sourceKeySelector, destinationKeySelector, createFunction, updateFunction, removeFunction, keepRemovedItemsInDestinationCollection, destinationFilter);
+            Extensions.SyncCollectionByKey(config, sourceCollectionSelector, sourceKeySelector, destinationKeySelector, mapper, createFunction, updateFunction, removeFunction, keepRemovedItemsInDestinationCollection, destinationFilter);
         }
 
     }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper.EntityFramework/Riganti.Utils.Infrastructure.AutoMapper.EntityFramework.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper.EntityFramework/Riganti.Utils.Infrastructure.AutoMapper.EntityFramework.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="5.0.2" />
+    <PackageReference Include="AutoMapper" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore/EntityFrameworkCoreExtensions.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore/EntityFrameworkCoreExtensions.cs
@@ -96,6 +96,7 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
                 Expression<Func<TSource, ICollection<TSourceItem>>> sourceCollectionSelector,
                 Func<TSourceItem, TKey> sourceKeySelector,
                 Func<TDestinationItem, TKey> destinationKeySelector,
+                IMapper mapper,
                 Func<TSourceItem, TDestinationItem> createFunction = null,
                 Action<TSourceItem, TDestinationItem> updateFunction = null,
                 Action<TDestinationItem> removeFunction = null,
@@ -114,7 +115,7 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
                 };
             }
 
-            Extensions.SyncCollectionByKey(config, sourceCollectionSelector, sourceKeySelector, destinationKeySelector, createFunction, updateFunction, removeFunction, keepRemovedItemsInDestinationCollection, destinationFilter);
+            Extensions.SyncCollectionByKey(config, sourceCollectionSelector, sourceKeySelector, destinationKeySelector, mapper, createFunction, updateFunction, removeFunction, keepRemovedItemsInDestinationCollection, destinationFilter);
         }
 
     }

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore/Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore/Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -24,16 +23,8 @@
   </PropertyGroup>
 
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
   <ItemGroup>
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="AutoMapper" Version="9.0.0" />
   </ItemGroup>
 

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore/Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore/Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore</PackageId>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="5.0.2" />
+    <PackageReference Include="AutoMapper" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/DropAndCreateCollectionResolver.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/DropAndCreateCollectionResolver.cs
@@ -15,14 +15,27 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
 
         public Func<TDestinationItem, bool> DestinationFilter { get; }
 
-        public DropAndCreateCollectionResolver(Func<TSourceItem, TDestinationItem> projection = null, Action<TDestinationItem> removeCallback = null, Func<TDestinationItem, bool> destinationFilter = null)
+        
+        public DropAndCreateCollectionResolver(IMapper mapper,
+            Action<TDestinationItem> removeCallback = null,
+            Func<TDestinationItem, bool> destinationFilter = null) : this(removeCallback, destinationFilter)
         {
-            this.Projection = projection ?? Mapper.Map<TSourceItem, TDestinationItem>;
+            this.Projection = mapper.Map<TSourceItem, TDestinationItem>;
+        }
+        
+        public DropAndCreateCollectionResolver(
+            Func<TSourceItem, TDestinationItem> projection = null,
+            Action<TDestinationItem> removeCallback = null,
+            Func<TDestinationItem, bool> destinationFilter = null) : this(removeCallback, destinationFilter)
+        {
+            this.Projection = projection;
+        }
+
+        private DropAndCreateCollectionResolver(Action<TDestinationItem> removeCallback = null, Func<TDestinationItem, bool> destinationFilter = null)
+        {
             this.RemoveCallback = removeCallback ?? (_ => {});
             this.DestinationFilter = destinationFilter ?? (_ => true);
         }
-
-
 
         public ICollection<TDestinationItem> Resolve(TSource source, TDestination destination, ICollection<TSourceItem> sourceMember, ICollection<TDestinationItem> destMember, ResolutionContext context)
         {

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/EntityDTOMapper.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/EntityDTOMapper.cs
@@ -5,19 +5,26 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
 {
     public class EntityDTOMapper<TEntity, TDTO> : IEntityDTOMapper<TEntity, TDTO>
     {
+        private readonly IMapper mapper;
+
+        public EntityDTOMapper(IMapper mapper)
+        {
+            this.mapper = mapper;
+        }
+        
         public TDTO MapToDTO(TEntity source)
         {
-            return Mapper.Map<TDTO>(source);
+            return mapper.Map<TDTO>(source);
         }
 
         public TEntity MapToEntity(TDTO source)
         {
-            return Mapper.Map<TEntity>(source);
+            return mapper.Map<TEntity>(source);
         }
 
         public void PopulateEntity(TDTO source, TEntity target)
         {
-            Mapper.Map(source, target);
+            mapper.Map(source, target);
         }
     }
     

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/Extensions.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/Extensions.cs
@@ -20,7 +20,7 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
                 Func<TDestinationItem, bool> destinationFilter = null
             )
         {
-            config.ResolveUsing(new DropAndCreateCollectionResolver<TSource, TSourceItem, TDestination, TDestinationItem>(projection, removeCallback, destinationFilter), sourceCollectionSelector);
+            config.MapFrom(new DropAndCreateCollectionResolver<TSource, TSourceItem, TDestination, TDestinationItem>(projection, removeCallback, destinationFilter), sourceCollectionSelector);
         }
 
         private static void SyncCollectionByKeyReflectionOnly<TSource, TSourceItem, TDestination, TDestinationItem, TKey>
@@ -29,6 +29,7 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
                 Expression<Func<TSource, ICollection<TSourceItem>>> sourceCollectionSelector,
                 Expression<Func<TSourceItem, TKey>> sourceKeySelector,
                 Expression<Func<TDestinationItem, TKey>> destinationSelector,
+                IMapper mapper,
                 Func<TSourceItem, TDestinationItem> createFunction = null,
                 Action<TSourceItem, TDestinationItem> updateFunction = null,
                 Action<TDestinationItem> removeFunction = null,
@@ -36,7 +37,7 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
                 Func<TDestinationItem, bool> destinationFilter = null
             )
         {
-            SyncCollectionByKey(config, sourceCollectionSelector, sourceKeySelector.Compile(), destinationSelector.Compile(), createFunction, updateFunction, removeFunction, keepRemovedItemsInDestinationCollection, destinationFilter);
+            SyncCollectionByKey(config, sourceCollectionSelector, sourceKeySelector.Compile(), destinationSelector.Compile(), mapper, createFunction, updateFunction, removeFunction, keepRemovedItemsInDestinationCollection, destinationFilter);
         }
 
 
@@ -46,6 +47,7 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
                 Expression<Func<TSource, ICollection<TSourceItem>>> sourceCollectionSelector,
                 Func<TSourceItem, TKey> sourceKeySelector,
                 Func<TDestinationItem, TKey> destinationSelector,
+                IMapper mapper,
                 Func<TSourceItem, TDestinationItem> createFunction = null,
                 Action<TSourceItem, TDestinationItem> updateFunction = null,
                 Action<TDestinationItem> removeFunction = null,
@@ -53,12 +55,12 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
                 Func<TDestinationItem, bool> destinationFilter = null
             )
         {
-            config.ResolveUsing(new SyncByKeyCollectionResolver<TSource, TSourceItem, TDestination, TDestinationItem, TKey>()
+            config.MapFrom(new SyncByKeyCollectionResolver<TSource, TSourceItem, TDestination, TDestinationItem, TKey>()
             {
                 SourceKeySelector = sourceKeySelector,
                 DestinationKeySelector = destinationSelector,
-                CreateFunction = createFunction ?? Mapper.Map<TSourceItem, TDestinationItem>,
-                UpdateFunction = updateFunction ?? ((s, d) => Mapper.Map(s, d)),
+                CreateFunction = createFunction ?? mapper.Map<TSourceItem, TDestinationItem>,
+                UpdateFunction = updateFunction ?? ((s, d) => mapper.Map(s, d)),
                 RemoveFunction = removeFunction ?? (d => { }),
                 KeepRemovedItemsInDestinationCollection = keepRemovedItemsInDestinationCollection,
                 DestinationFilter = destinationFilter ?? (e => true)

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/Riganti.Utils.Infrastructure.AutoMapper.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/Riganti.Utils.Infrastructure.AutoMapper.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.AutoMapper</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.AutoMapper</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -27,13 +27,8 @@
     <ProjectReference Include="..\Riganti.Utils.Infrastructure.Services\Riganti.Utils.Infrastructure.Services.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup>
     <PackageReference Include="System.Reflection" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/Riganti.Utils.Infrastructure.AutoMapper.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/Riganti.Utils.Infrastructure.AutoMapper.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.AutoMapper</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.AutoMapper</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -28,7 +27,7 @@
     <ProjectReference Include="..\Riganti.Utils.Infrastructure.Services\Riganti.Utils.Infrastructure.Services.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Reflection" Version="4.3.0" />
   </ItemGroup>
 
@@ -38,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="5.0.2" />
+    <PackageReference Include="AutoMapper" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Azure.TableStorage/Riganti.Utils.Infrastructure.Azure.TableStorage.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Azure.TableStorage/Riganti.Utils.Infrastructure.Azure.TableStorage.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Azure.TableStorage</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Azure.TableStorage</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -32,12 +31,7 @@
     <ProjectReference Include="..\Riganti.Utils.Infrastructure.Core\Riganti.Utils.Infrastructure.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Configuration/Riganti.Utils.Infrastructure.Configuration.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Configuration/Riganti.Utils.Infrastructure.Configuration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Riganti.Utils.Infrastructure.Configuration</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Configuration</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -24,13 +24,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Riganti.Utils.Infrastructure.Core\Riganti.Utils.Infrastructure.Core.csproj" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Core/Riganti.Utils.Infrastructure.Core.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Core/Riganti.Utils.Infrastructure.Core.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Core</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Core</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -24,22 +23,17 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.6|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NETSTANDARD1_6</DefineConstants>
     <OutputPath>bin\Debug\netstandard1.6\</OutputPath>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup>
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.DotVVM/Riganti.Utils.Infrastructure.DotVVM.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.DotVVM/Riganti.Utils.Infrastructure.DotVVM.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.DotVVM</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.DotVVM</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -29,10 +29,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DotVVM.Core" Version="1.1.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/Riganti.Utils.Infrastructure.EntityFramework.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFramework/Riganti.Utils.Infrastructure.EntityFramework.csproj
@@ -24,7 +24,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <ProjectReference Include="..\Riganti.Utils.Infrastructure.Core\Riganti.Utils.Infrastructure.Core.csproj" />
-    <PackageReference Include="EntityFramework" Version="6.1.3" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
@@ -32,6 +31,10 @@
 
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="EntityFramework" Version="6.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/Riganti.Utils.Infrastructure.EntityFrameworkCore.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.EntityFrameworkCore/Riganti.Utils.Infrastructure.EntityFrameworkCore.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.EntityFrameworkCore</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.EntityFrameworkCore</PackageId>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -29,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Logging.ApplicationInsights/Riganti.Utils.Infrastructure.Logging.ApplicationInsights.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Logging.ApplicationInsights/Riganti.Utils.Infrastructure.Logging.ApplicationInsights.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Logging.ApplicationInsights</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Logging.ApplicationInsights</PackageId>
-    <NetStandardImplicitPackageVersion Condition="'$(TargetFramework)' == 'netstandard1.6'">1.6.1</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Logging.Email/Riganti.Utils.Infrastructure.Logging.Email.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Logging.Email/Riganti.Utils.Infrastructure.Logging.Email.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.0-rc2</VersionPrefix>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Logging.Email</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Logging.Email</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -24,12 +23,7 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Logging/Riganti.Utils.Infrastructure.Logging.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Logging/Riganti.Utils.Infrastructure.Logging.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Logging</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Logging</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -26,12 +24,7 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Azure/Riganti.Utils.Infrastructure.Services.Azure.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Azure/Riganti.Utils.Infrastructure.Services.Azure.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Azure</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Azure</PackageId>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -30,11 +29,6 @@
 
   <ItemGroup>
     <PackageReference Include="WindowsAzure.Storage" Version="8.1.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing.AmazonSes/Riganti.Utils.Infrastructure.Services.Mailing.AmazonSes.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing.AmazonSes/Riganti.Utils.Infrastructure.Services.Mailing.AmazonSes.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.2.0-rc2</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <VersionPrefix>2.2.2</VersionPrefix>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Amazon.SES</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Amazon.SES</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -31,11 +29,6 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SimpleEmail" Version="3.3.1.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing.MailKit/Riganti.Utils.Infrastructure.Services.Mailing.MailKit.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing.MailKit/Riganti.Utils.Infrastructure.Services.Mailing.MailKit.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <VersionPrefix>2.2.0-rc2</VersionPrefix>
-        <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+        <VersionPrefix>2.2.2</VersionPrefix>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <PackageId>Riganti.Utils.Infrastructure.Services.Amazon.SES</PackageId>
-        <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
-        <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
         <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
         <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
         <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing.SendGrid/Riganti.Utils.Infrastructure.Services.Mailing.SendGrid.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing.SendGrid/Riganti.Utils.Infrastructure.Services.Mailing.SendGrid.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.2.0-rc2</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <VersionPrefix>2.2.2</VersionPrefix>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.SendGrid</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.SendGrid</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -26,11 +24,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Riganti.Utils.Infrastructure.Services.Mailing\Riganti.Utils.Infrastructure.Services.Mailing.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing.SystemSmtpClient/Riganti.Utils.Infrastructure.Services.Mailing.SystemSmtpClient.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing.SystemSmtpClient/Riganti.Utils.Infrastructure.Services.Mailing.SystemSmtpClient.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <VersionPrefix>2.2.0-rc2</VersionPrefix>
-        <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+        <VersionPrefix>2.2.2</VersionPrefix>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <PackageId>Riganti.Utils.Infrastructure.Services.Amazon.SES</PackageId>
-        <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
-        <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
         <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
         <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
         <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -24,13 +22,8 @@
     </PropertyGroup>
     
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-        <Reference Include="System" />
-        <Reference Include="System.Net" />
-        <Reference Include="Microsoft.CSharp" />
-    </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     </ItemGroup>
 

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing/Riganti.Utils.Infrastructure.Services.Mailing.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services.Mailing/Riganti.Utils.Infrastructure.Services.Mailing.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services.Mailing</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services.Mailing</PackageId>
-    <NetStandardImplicitPackageVersion Condition="'$(TargetFramework)' == 'netstandard1.6'">1.6.1</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -23,14 +21,8 @@
     <PackageIconUrl>https://raw.githubusercontent.com/riganti/infrastructure/master/img/logo_64x64_transparent.png</PackageIconUrl>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
-
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  
+  <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Services/Riganti.Utils.Infrastructure.Services.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Services/Riganti.Utils.Infrastructure.Services.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Services</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Services</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -36,12 +35,7 @@
     <ProjectReference Include="..\Riganti.Utils.Infrastructure.Core\Riganti.Utils.Infrastructure.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.Testing/Riganti.Utils.Infrastructure.Testing.csproj
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.Testing/Riganti.Utils.Infrastructure.Testing.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.2.2</VersionPrefix>
-    <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Testing</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Testing</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.sln
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.sln
@@ -41,8 +41,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Riganti.Utils.Infrastructur
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests", "Tests\Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests\Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests.csproj", "{1373AA88-83A9-48E2-8C29-782135CB98AD}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Riganti.Utils.Infrastructure.AutoMapper.EntityFramework", "Riganti.Utils.Infrastructure.AutoMapper.EntityFramework\Riganti.Utils.Infrastructure.AutoMapper.EntityFramework.csproj", "{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore", "Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore\Riganti.Utils.Infrastructure.AutoMapper.EntityFrameworkCore.csproj", "{584AF547-0311-4EEA-AC86-83F082C0BFEA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Riganti.Utils.Infrastructure.Services.Mailing.Tests", "Tests\Riganti.Utils.Infrastructure.Services.Mailing.Tests\Riganti.Utils.Infrastructure.Services.Mailing.Tests.csproj", "{7EFFD697-35E1-4A38-9E80-5710DC8601D2}"
@@ -302,18 +300,6 @@ Global
 		{1373AA88-83A9-48E2-8C29-782135CB98AD}.Release|x64.Build.0 = Release|Any CPU
 		{1373AA88-83A9-48E2-8C29-782135CB98AD}.Release|x86.ActiveCfg = Release|Any CPU
 		{1373AA88-83A9-48E2-8C29-782135CB98AD}.Release|x86.Build.0 = Release|Any CPU
-		{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}.Debug|x64.Build.0 = Debug|Any CPU
-		{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}.Debug|x86.Build.0 = Debug|Any CPU
-		{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}.Release|x64.ActiveCfg = Release|Any CPU
-		{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}.Release|x64.Build.0 = Release|Any CPU
-		{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}.Release|x86.ActiveCfg = Release|Any CPU
-		{EC3A0C41-9EED-45A8-8341-CAB17B11DD85}.Release|x86.Build.0 = Release|Any CPU
 		{584AF547-0311-4EEA-AC86-83F082C0BFEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{584AF547-0311-4EEA-AC86-83F082C0BFEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{584AF547-0311-4EEA-AC86-83F082C0BFEA}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Azure.TableStorage.Tests/Riganti.Utils.Infrastructure.Azure.TableStorage.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Azure.TableStorage.Tests/Riganti.Utils.Infrastructure.Azure.TableStorage.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp1.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <Company>RIGANTI</Company>
     <AssemblyName>Riganti.Utils.Infrastructure.Azure.TableStorage.Tests</AssemblyName>
     <PackageId>Riganti.Utils.Infrastructure.Azure.TableStorage.Tests</PackageId>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/DateTimeNowProvider/UtcDateTimeNowProviderTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/DateTimeNowProvider/UtcDateTimeNowProviderTests.cs
@@ -12,7 +12,14 @@ namespace Riganti.Utils.Infrastructure.Core.Tests.DateTimeNowProvider
         {
             var utcDateTimeNowProviderValue = utcDateTimeProviderSUT.Now;
 
-            Assert.True(DateTime.Compare(utcDateTimeNowProviderValue, DateTime.UtcNow) == 0);
+            Assert.True(AreDateTimeClose(DateTime.Now, utcDateTimeNowProviderValue));
+        }
+
+        public bool AreDateTimeClose(DateTime time, DateTime time2)
+        {
+            if (time.AddSeconds(-2) > time2 && time2 < time.AddSeconds(2))
+                return true;
+            return false;
         }
     }
 }

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Riganti.Utils.Infrastructure.Core.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Core.Tests/Riganti.Utils.Infrastructure.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <AssemblyName>Riganti.Utils.Infrastructure.Core.Tests</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Riganti.Utils.Infrastructure.Core.Tests</PackageId>

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests/Riganti.Utils.Infrastructure.EntityFramework.Tests.csproj
@@ -32,13 +32,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="EntityFramework" Version="6.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="EntityFramework" Version="6.1.3" />
     <PackageReference Include="moq" Version="4.7.145" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests/Riganti.Utils.Infrastructure.EntityFrameworkCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp1.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
     <PackageReference Include="moq" Version="4.7.145" />
   </ItemGroup>
 

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Tests/Facades/TemporalRelationshipCrudFacadeTests.cs
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Tests/Facades/TemporalRelationshipCrudFacadeTests.cs
@@ -55,7 +55,8 @@ namespace Riganti.Utils.Infrastructure.Services.Tests.Facades
         {
             // Arrange
             var options = CreateInMemoryDatabase();
-            var facade = GetFacade(options);
+            var mapper = InitializeMapper();
+            var facade = GetFacade(options, mapper);
 
             // Act
             var detail = facade.GetDetail(100);
@@ -69,7 +70,8 @@ namespace Riganti.Utils.Infrastructure.Services.Tests.Facades
         {
             // Arrange
             var options = CreateInMemoryDatabase();
-            var facade = GetFacade(options);
+            var mapper = InitializeMapper();
+            var facade = GetFacade(options, mapper);
 
             // Act
             var detail = facade.GetDetail(-1);
@@ -92,7 +94,8 @@ namespace Riganti.Utils.Infrastructure.Services.Tests.Facades
         {
             // Arrange
             var options = CreateInMemoryDatabase();
-            var facade = GetFacade(options);
+            var mapper = InitializeMapper();
+            var facade = GetFacade(options, mapper);
             var employeeId = 1; // has only one project
             EmployeeProject employeeProject;
             // get current EmployeeProject for the employee
@@ -100,7 +103,7 @@ namespace Riganti.Utils.Infrastructure.Services.Tests.Facades
             {
                 employeeProject = ctx.EmployeeProjects.Single(ep => ep.EmployeeId == employeeId);
             }
-            var employeeProjectDTO = Mapper.Map<EmployeeProjectDTO>(employeeProject);
+            var employeeProjectDTO = mapper.Map<EmployeeProjectDTO>(employeeProject);
             
             // Act
             var savedDTO = facade.Save(employeeProjectDTO);
@@ -127,7 +130,8 @@ namespace Riganti.Utils.Infrastructure.Services.Tests.Facades
         {
             // Arrange
             var options = CreateInMemoryDatabase();
-            var facade = GetFacade(options);
+            var mapper = InitializeMapper();
+            var facade = GetFacade(options, mapper);
             EmployeeProject employeeProject;
             // get the EmployeeProject
             using (var ctx = new EmployeeProjectDbContext(options))
@@ -136,7 +140,7 @@ namespace Riganti.Utils.Infrastructure.Services.Tests.Facades
             }
             var employeeId = employeeProject.EmployeeId;
             var projectId = employeeProject.ProjectId;
-            var employeeProjectDTO = Mapper.Map<EmployeeProjectDTO>(employeeProject);
+            var employeeProjectDTO = mapper.Map<EmployeeProjectDTO>(employeeProject);
 
             // Act
             facade.Delete(employeeProjectDTO);
@@ -159,7 +163,8 @@ namespace Riganti.Utils.Infrastructure.Services.Tests.Facades
         {
             // Arrange
             var options = CreateInMemoryDatabase();
-            var facade = GetFacade(options);
+            var mapper = InitializeMapper();
+            var facade = GetFacade(options, mapper);
             EmployeeProject employeeProject;
             // get the EmployeeProject
             using (var ctx = new EmployeeProjectDbContext(options))
@@ -183,22 +188,28 @@ namespace Riganti.Utils.Infrastructure.Services.Tests.Facades
             Assert.True(employeeProjects.All(ep => ep.ValidityEndDate < DateTime.Now));
         }
 
-        private static EmployeeProjectsFacade GetFacade(DbContextOptions<EmployeeProjectDbContext> options)
+        private static EmployeeProjectsFacade GetFacade(DbContextOptions<EmployeeProjectDbContext> options, IMapper mapper)
         {
-            Mapper.Initialize(cfg =>
+            var dateTimeProvider = new LocalDateTimeProvider();
+            IUnitOfWorkProvider unitOfWorkProvider = new EntityFrameworkUnitOfWorkProvider(new AsyncLocalUnitOfWorkRegistry(), () => new EmployeeProjectDbContext(options));
+            Func<IFilteredQuery<EmployeeProjectDTO, EmployeeProjectFilterDTO>> queryFactory = () => new Mock<IFilteredQuery<EmployeeProjectDTO, EmployeeProjectFilterDTO>>().Object;
+            var entityMapper = new EntityDTOMapper<EmployeeProject, EmployeeProjectDTO>(mapper);
+            var respository = new EntityFrameworkRepository<EmployeeProject, int>(unitOfWorkProvider, dateTimeProvider);
+            var parentRepository = new EntityFrameworkRepository<Employee, int>(unitOfWorkProvider, dateTimeProvider);
+            var facade = new EmployeeProjectsFacade(queryFactory, entityMapper, respository, parentRepository, dateTimeProvider, unitOfWorkProvider);
+            return facade;
+        }
+
+        private static IMapper InitializeMapper()
+        {
+            
+            var configuration = new MapperConfiguration(cfg =>
             {
                 cfg.CreateMap<EmployeeProjectDTO, EmployeeProject>();
                 cfg.CreateMap<EmployeeProject, EmployeeProjectDTO>();
             });
 
-            var dateTimeProvider = new LocalDateTimeProvider();
-            IUnitOfWorkProvider unitOfWorkProvider = new EntityFrameworkUnitOfWorkProvider(new AsyncLocalUnitOfWorkRegistry(), () => new EmployeeProjectDbContext(options));
-            Func<IFilteredQuery<EmployeeProjectDTO, EmployeeProjectFilterDTO>> queryFactory = () => new Mock<IFilteredQuery<EmployeeProjectDTO, EmployeeProjectFilterDTO>>().Object;
-            var entityMapper = new EntityDTOMapper<EmployeeProject, EmployeeProjectDTO>();
-            var respository = new EntityFrameworkRepository<EmployeeProject, int>(unitOfWorkProvider, dateTimeProvider);
-            var parentRepository = new EntityFrameworkRepository<Employee, int>(unitOfWorkProvider, dateTimeProvider);
-            var facade = new EmployeeProjectsFacade(queryFactory, entityMapper, respository, parentRepository, dateTimeProvider, unitOfWorkProvider);
-            return facade;
+            return configuration.CreateMapper();
         }
 
         private static void PrepareInMemoryDbContext(DbContextOptions<EmployeeProjectDbContext> options)

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Tests/Riganti.Utils.Infrastructure.Services.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Tests/Riganti.Utils.Infrastructure.Services.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="5.0.2" />
+    <PackageReference Include="AutoMapper" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.145" />

--- a/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Tests/Riganti.Utils.Infrastructure.Services.Tests.csproj
+++ b/src/Infrastructure/Tests/Riganti.Utils.Infrastructure.Services.Tests/Riganti.Utils.Infrastructure.Services.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -10,12 +10,12 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates automapper to version 9 with minimal changes.

This PR introduces folowing breaking changes:

Class DropAndCreateCollectionResolver has now two constructors instead of one. One of the new constructors takes as argument IMapper.

Constructor in class EntityDTOMapper now takes IAutomapper as argument instead of being empty.

SyncCollectionByKey now takes additional argument IMapper.

SyncCollectionByKeyReflectionOnly now takes additional argument IMapper.

resolves #44