### PR TITLE
Fix collection synchronization

### DIFF
--- a/src/Infrastructure/Directory.Build.props
+++ b/src/Infrastructure/Directory.Build.props
@@ -1,0 +1,5 @@
+﻿<Project>
+    <PropertyGroup>
+        <LangVersion>latestMajor</LangVersion>
+    </PropertyGroup>
+</Project>

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/Extensions.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/Extensions.cs
@@ -38,17 +38,17 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
 
 
         public static void SyncCollectionByKey<TSource, TSourceItem, TDestination, TDestinationItem, TKey>
-            (
-                this IMemberConfigurationExpression<TSource, TDestination, ICollection<TDestinationItem>> config,
-                Expression<Func<TSource, ICollection<TSourceItem>>> sourceCollectionSelector,
-                Func<TSourceItem, TKey> sourceKeySelector,
-                Func<TDestinationItem, TKey> destinationSelector,
-                Func<TSourceItem, TDestinationItem> createFunction = null,
-                Action<TSourceItem, TDestinationItem> updateFunction = null,
-                Action<TDestinationItem> removeFunction = null,
-                bool keepRemovedItemsInDestinationCollection = false,
-                Func<TDestinationItem, bool> destinationFilter = null
-            )
+        (
+            this IMemberConfigurationExpression<TSource, TDestination, ICollection<TDestinationItem>> config,
+            Expression<Func<TSource, ICollection<TSourceItem>>> sourceCollectionSelector,
+            Func<TSourceItem, TKey> sourceKeySelector,
+            Func<TDestinationItem, TKey> destinationSelector,
+            Func<TSourceItem, TDestinationItem> createFunction = null,
+            Action<TSourceItem, TDestinationItem> updateFunction = null,
+            Action<TDestinationItem> removeFunction = null,
+            bool keepRemovedItemsInDestinationCollection = false,
+            Func<TDestinationItem, bool> destinationFilter = null
+        )
         {
             config.MapFrom(new SyncByKeyCollectionResolver<TSource, TSourceItem, TDestination, TDestinationItem, TKey>()
             {
@@ -58,7 +58,7 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
                 UpdateFunction = updateFunction,
                 RemoveFunction = removeFunction,
                 KeepRemovedItemsInDestinationCollection = keepRemovedItemsInDestinationCollection,
-                DestinationFilter = destinationFilter
+                DestinationFilter = destinationFilter ?? (_ => true) 
             }, sourceCollectionSelector);
         }
 

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/SyncByKeyCollectionResolver.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/SyncByKeyCollectionResolver.cs
@@ -27,6 +27,10 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
 
         public ICollection<TDestinationItem> Resolve(TSource source, TDestination destination, ICollection<TSourceItem> sourceMember, ICollection<TDestinationItem> destMember, ResolutionContext context)
         {
+            if (SourceKeySelector is null) throw new InvalidOperationException($"{nameof(SourceKeySelector)} has not been set for {typeof(SyncByKeyCollectionResolver<TSource, TSourceItem, TDestination, TDestinationItem, TKey>)}.");
+            if (DestinationFilter is null) throw new InvalidOperationException($"{nameof(DestinationFilter)} has not been set for {typeof(SyncByKeyCollectionResolver<TSource, TSourceItem, TDestination, TDestinationItem, TKey>)}."); 
+            if (DestinationKeySelector is null) throw new InvalidOperationException($"{nameof(DestinationKeySelector)} has not been set for {typeof(SyncByKeyCollectionResolver<TSource, TSourceItem, TDestination, TDestinationItem, TKey>)}."); 
+            
             var createFunction = CreateFunction ?? context.Mapper.Map<TSourceItem, TDestinationItem>;
             var updateFunction = UpdateFunction ?? ((s, d) => context.Mapper.Map(s, d));
             var removeFunction = RemoveFunction ?? (d => { });

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/SyncByKeyCollectionResolver.cs
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.AutoMapper/SyncByKeyCollectionResolver.cs
@@ -31,6 +31,7 @@ namespace Riganti.Utils.Infrastructure.AutoMapper
             if (DestinationFilter is null) throw new InvalidOperationException($"{nameof(DestinationFilter)} has not been set for {typeof(SyncByKeyCollectionResolver<TSource, TSourceItem, TDestination, TDestinationItem, TKey>)}."); 
             if (DestinationKeySelector is null) throw new InvalidOperationException($"{nameof(DestinationKeySelector)} has not been set for {typeof(SyncByKeyCollectionResolver<TSource, TSourceItem, TDestination, TDestinationItem, TKey>)}."); 
             
+            destMember ??= new List<TDestinationItem>();
             var createFunction = CreateFunction ?? context.Mapper.Map<TSourceItem, TDestinationItem>;
             var updateFunction = UpdateFunction ?? ((s, d) => context.Mapper.Map(s, d));
             var removeFunction = RemoveFunction ?? (d => { });

--- a/src/Infrastructure/Riganti.Utils.Infrastructure.sln
+++ b/src/Infrastructure/Riganti.Utils.Infrastructure.sln
@@ -81,6 +81,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C95B8244-DF34-4433-BD87-D2AABFA8AB43}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		clean-bin-obj.cmd = clean-bin-obj.cmd
+		clean-bin-obj-packages.cmd = clean-bin-obj-packages.cmd
+		Directory.Build.props = Directory.Build.props
+		Riganti.Utils.Infrastructure.sln.DotSettings = Riganti.Utils.Infrastructure.sln.DotSettings
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
Fixed usage of `SyncByKeyCollectionResolver`
- When destination member (mapped collection) is null, calling `destMember.Where(...)` thrown `ArgumentNullException`
- Addech checks for `SourceKeySelector`, `DestinationFilter`, `DestinationKeySelector` with custom error messages to help debug problems.